### PR TITLE
fix(ci): use Xcode's Swift toolchain for release build

### DIFF
--- a/.github/actions/setup-swift-client/action.yml
+++ b/.github/actions/setup-swift-client/action.yml
@@ -8,8 +8,16 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Set up Swift
-      uses: swift-actions/setup-swift@v2
+    # Use Xcode's bundled Swift toolchain, which matches the runner's SDK.
+    # Do NOT install a standalone toolchain (e.g. swift-actions/setup-swift):
+    # it shadows Xcode's swift and, when its version drifts from the runner's
+    # Xcode SDK, `swift build` fails with "this SDK is not supported by the
+    # compiler / failed to build module 'Darwin'".
+    - name: Show Swift toolchain
+      shell: bash
+      run: |
+        xcode-select -p
+        swift --version
 
     - name: Cache Swift build
       uses: actions/cache@v4


### PR DESCRIPTION
## Problem
The `v0.8.7.26` release run failed at **Build macOS Swift Client → Build Swift client**:

> `failed to build module 'Darwin'; this SDK is not supported by the compiler (SDK built with Swift 6.3.2, compiler is Swift 6.1). Please select a toolchain which matches the SDK.`

`.github/actions/setup-swift-client` ran `swift-actions/setup-swift@v2`, which installs a standalone **Swift 6.1** toolchain that shadows Xcode's. The hosted runner's Xcode moved to **26.6 (SDK Swift 6.3.2)**, so `swift build` used the mismatched 6.1 compiler against the 26.5 SDK and failed. (It last worked in Nov 2025 when the versions happened to align.)

## Fix
Drop the standalone toolchain step so `swift build` uses Xcode's bundled Swift, which always matches the runner's SDK. Adds a small `swift --version` / `xcode-select -p` diagnostic step in its place.

After merge: re-run the **Release 🎉** workflow for `v0.8.7.26` from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)