### PR TITLE
fix(ci): build committed gRPC stubs (don't regenerate in release)

### DIFF
--- a/.github/actions/setup-swift-client/action.yml
+++ b/.github/actions/setup-swift-client/action.yml
@@ -30,25 +30,12 @@ runs:
         restore-keys: |
           ${{ runner.os }}-swift-build-
 
-    - name: Cache Homebrew
-      uses: actions/cache@v4
-      with:
-        path: |
-          ~/Library/Caches/Homebrew
-          /opt/homebrew/Cellar/swift-protobuf
-          /opt/homebrew/Cellar/grpc-swift
-        key: ${{ runner.os }}-brew-${{ hashFiles('scripts/generate_proto.sh') }}
-        restore-keys: |
-          ${{ runner.os }}-brew-
-
-    - name: Install Protoc
-      uses: arduino/setup-protoc@v3
-      with:
-        repo-token: ${{ github.token }}
-        version: "23.x"
-
-    - name: Generate protobuf
-      shell: bash
-      run: |
-        chmod +x scripts/generate_proto.sh
-        ./scripts/generate_proto.sh -t ${{ inputs.proto-target }}
+    # NOTE: We deliberately do NOT regenerate the protobuf/gRPC stubs in CI.
+    # `VCStubs/` is committed and generated against the pinned grpc-swift-2
+    # runtime (Package.resolved). Regenerating here used `brew install
+    # grpc-swift`, whose protoc-gen-grpc-swift version drifts from the pinned
+    # runtime and emits mismatched code — e.g. `MethodDescriptor(…, type:)`,
+    # which the pinned GRPCCore rejects ("extra argument 'type' in call").
+    # The committed stubs already compile against the pinned runtime (this is
+    # exactly what `just swift-build` does locally), so we build them as-is.
+    # To update stubs, run `just proto-gen` locally and commit VCStubs/.


### PR DESCRIPTION
## Problem
After the toolchain fix (#18), the release build got further but failed compiling the generated gRPC stubs:

> `VCStubs/vibecare.grpc.swift:34: error: extra argument 'type' in call` — `MethodDescriptor(service:method:type: .unary)`

`setup-swift-client` regenerated stubs via `generate_proto.sh` → `brew install grpc-swift`. That plugin's version drifts from the project's pinned **grpc-swift-2 (2.2.0)** runtime and emits `MethodDescriptor(…, type:)`, which the pinned `GRPCCore` doesn't accept. The **committed** `VCStubs/` were generated against the pinned runtime and compile (that's what `just swift-build` uses locally).

## Fix
Drop the CI proto-regeneration (and its protoc/brew steps) from `setup-swift-client`; build the committed stubs as-is. To update stubs, run `just proto-gen` locally and commit `VCStubs/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)