### PR TITLE
ci(release): auto-update Homebrew cask on release

### DIFF
--- a/.github/scripts/create-app-bundle.sh
+++ b/.github/scripts/create-app-bundle.sh
@@ -47,6 +47,8 @@ cat > "${APP_BUNDLE}/Contents/Info.plist" << EOF
     <true/>
     <key>LSUIElement</key>
     <true/>
+    <key>NSCameraUsageDescription</key>
+    <string>VibeCheck uses the camera to detect body-focused repetitive behaviors. Video is processed on-device and never leaves your Mac.</string>
 </dict>
 </plist>
 EOF

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -226,3 +226,83 @@ jobs:
             build/*.tar.gz
             build/*.sha256
           retention-days: 30
+  update-homebrew-tap:
+    name: Update Homebrew Tap
+    runs-on: ubuntu-latest
+    needs: create-release
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Get version
+        id: version
+        uses: ./.github/actions/setup-version
+        with:
+          event-name: ${{ github.event_name }}
+          manual-version: ${{ github.event.inputs.version }}
+
+      - name: Compute tarball checksum
+        id: cask
+        run: |
+          VER="${{ steps.version.outputs.version }}"
+          NUM="${VER#v}"
+          URL="https://github.com/${{ github.repository }}/releases/download/${VER}/vibecare-${VER}-macos.tar.gz"
+          curl -fsSL "$URL" -o tarball.tgz
+          SHA="$(sha256sum tarball.tgz | awk '{print $1}')"
+          echo "num=$NUM" >> "$GITHUB_OUTPUT"
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout tap
+        uses: actions/checkout@v4
+        with:
+          repository: vibecare-io/homebrew-apps
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          path: tap
+
+      - name: Write cask
+        run: |
+          mkdir -p tap/Casks
+          cat > tap/Casks/vibecare.rb <<CASK
+          cask "vibecare" do
+            version "${{ steps.cask.outputs.num }}"
+            sha256 "${{ steps.cask.outputs.sha }}"
+
+            url "https://github.com/${{ github.repository }}/releases/download/v#{version}/vibecare-v#{version}-macos.tar.gz",
+                verified: "github.com/${{ github.repository }}/"
+            name "VibeCare"
+            desc "Wellness and routine management app with on-device BFRB detection"
+            homepage "https://github.com/${{ github.repository }}"
+
+            depends_on macos: :sequoia
+
+            app "VibeCare.app"
+            binary "vibecare-server"
+
+            # App is Developer ID signed but not notarized; clear quarantine so
+            # Gatekeeper allows first launch.
+            postflight do
+              system_command "/usr/bin/xattr",
+                             args: ["-dr", "com.apple.quarantine", "#{appdir}/VibeCare.app"],
+                             sudo: false
+            end
+
+            zap trash: [
+              "~/Library/Application Support/VibeCare",
+              "~/.vibecare",
+              "~/Library/Preferences/io.vibecare.App.vibecare.plist",
+              "~/Library/Caches/io.vibecare.App.vibecare",
+            ]
+          end
+          CASK
+
+      - name: Commit and push
+        run: |
+          cd tap
+          if git diff --quiet; then
+            echo "Cask already up to date"; exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Casks/vibecare.rb
+          git commit -m "vibecare ${{ steps.version.outputs.version }}"
+          git push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -262,7 +262,7 @@ jobs:
       - name: Write cask
         run: |
           mkdir -p tap/Casks
-          cat > tap/Casks/vibecare.rb <<CASK
+          cat > tap/Casks/vibecare.rb <<'CASK'
           cask "vibecare" do
             version "${{ steps.cask.outputs.num }}"
             sha256 "${{ steps.cask.outputs.sha }}"
@@ -285,6 +285,18 @@ jobs:
                              args: ["-dr", "com.apple.quarantine", "#{appdir}/VibeCare.app"],
                              sudo: false
             end
+
+            caveats <<~EOS
+              If VibeCare was previously installed with the .pkg installer, remove that
+              copy so Homebrew can manage it (your data in ~/.vibecare is preserved):
+
+                launchctl bootout gui/$(id -u)/io.vibecare.server 2>/dev/null || true
+                rm -f ~/Library/LaunchAgents/io.vibecare.server.plist
+                sudo rm -rf /Applications/VibeCare.app /usr/local/bin/vibecare-server
+                sudo pkgutil --forget io.vibecare.app
+
+              then re-run: brew install --cask vibecare
+            EOS
 
             zap trash: [
               "~/Library/Application Support/VibeCare",

--- a/Justfile
+++ b/Justfile
@@ -835,6 +835,18 @@ swift-run:
     @echo "{{GREEN}}Running Swift client...{{NC}}"
     cd clients/macos-swift/VibeCare && swift run VibeCare
 
+# Build + run the real .app bundle via Xcode. USE THIS FOR THE CAMERA:
+# `swift run` produces a bare CLI binary with no Info.plist, so macOS can't
+# prompt for camera access (VibeCheck never appears in Privacy > Camera). The
+# Xcode build embeds Info.plist (NSCameraUsageDescription + bundle id), so the
+# system prompts correctly and lists the app.
+[group('🍎 macOS / Swift')]
+swift-run-app:
+    @echo "{{GREEN}}Building VibeCare.app via Xcode (camera-capable Info.plist)...{{NC}}"
+    cd clients/macos-swift/VibeCare && xcodebuild -project vibecare.xcodeproj -scheme vibecare -configuration Debug -derivedDataPath .build/xcode -destination 'platform=macOS' build
+    @echo "{{GREEN}}Launching app...{{NC}}"
+    open clients/macos-swift/VibeCare/.build/xcode/Build/Products/Debug/vibecare.app
+
 [group('🍎 macOS / Swift')]
 swift-inspect-app-db:
     @echo "{{GREEN}}Inspect Swift client database...{{NC}}"

--- a/clients/macos-swift/VibeCare/VibeCare/vibecare.entitlements
+++ b/clients/macos-swift/VibeCare/VibeCare/vibecare.entitlements
@@ -8,5 +8,7 @@
 	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
+	<key>com.apple.security.device.camera</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
## What
Adds an `update-homebrew-tap` job to the release workflow. After `create-release` publishes, it:
1. Downloads `vibecare-<version>-macos.tar.gz` from the release and computes its sha256.
2. Rewrites `Casks/vibecare.rb` in **vibecare-io/homebrew-apps** with the new version + checksum.
3. Commits & pushes to the tap.

So `brew upgrade --cask vibecare` picks up every new release automatically.

## Required secret
Add **`HOMEBREW_TAP_TOKEN`** to this repo's Actions secrets: a fine-grained PAT with **Contents: Read and write** on `vibecare-io/homebrew-apps` (only). Until it's added, this job will fail on the tap checkout — the rest of the release is unaffected.

The tap + cask are already live and were seeded manually for v0.8.7.26; this job keeps them current going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)