### PR TITLE
feat: self-managing bundled backend (SMAppService) + update-reload

### DIFF
--- a/.github/scripts/io.vibecare.server.plist
+++ b/.github/scripts/io.vibecare.server.plist
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>io.vibecare.server</string>
+    <key>BundleProgram</key>
+    <string>Contents/Resources/vibecare-server</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>Contents/Resources/vibecare-server</string>
+        <string>--port</string><string>50051</string>
+        <string>--web-port</string><string>8080</string>
+    </array>
+    <key>RunAtLoad</key><true/>
+    <key>KeepAlive</key>
+    <dict><key>SuccessfulExit</key><false/></dict>
+    <key>ProcessType</key><string>Background</string>
+</dict>
+</plist>

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,18 +162,6 @@ jobs:
           event-name: ${{ github.event_name }}
           manual-version: ${{ github.event.inputs.version }}
 
-      - name: Download backend artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: backend-binary
-          path: .
-
-      - name: Extract backend binary
-        run: |
-          tar -xvf backend-binary.tar
-          mkdir -p dist
-          mv vibecare-server dist/
-
       - name: Download client artifact
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -298,6 +298,9 @@ jobs:
               system_command "/usr/bin/xattr",
                              args: ["-dr", "com.apple.quarantine", "#{appdir}/VibeCare.app"],
                              sudo: false
+              system_command "/bin/launchctl",
+                             args: ["kickstart", "-k", "gui/#{Process.uid}/io.vibecare.server"],
+                             sudo: false
             end
 
             caveats <<~EOS

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -291,7 +291,6 @@ jobs:
             depends_on macos: :sequoia
 
             app "VibeCare.app"
-            binary "vibecare-server"
 
             # App is Developer ID signed but not notarized; clear quarantine so
             # Gatekeeper allows first launch.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,6 +70,7 @@ jobs:
   build-macos-client:
     name: Build macOS Swift Client
     runs-on: macos-latest
+    needs: build-backend
 
     steps:
       - name: Checkout code
@@ -108,6 +109,21 @@ jobs:
             "vibecare-client" \
             "${{ steps.version.outputs.version }}" \
             "io.vibecare.app"
+
+      - name: Download backend artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: backend-binary
+          path: .
+
+      - name: Embed server + LaunchAgent into app bundle
+        run: |
+          tar -xvf backend-binary.tar
+          mkdir -p VibeCare.app/Contents/Resources VibeCare.app/Contents/Library/LaunchAgents
+          cp vibecare-server VibeCare.app/Contents/Resources/vibecare-server
+          chmod +x VibeCare.app/Contents/Resources/vibecare-server
+          cp .github/scripts/io.vibecare.server.plist \
+             VibeCare.app/Contents/Library/LaunchAgents/io.vibecare.server.plist
 
       - name: Sign app bundle
         uses: ./.github/actions/sign-app-bundle
@@ -182,8 +198,7 @@ jobs:
         run: |
           mkdir -p build
           cd dist
-          tar -czf ../build/vibecare-${{ steps.version.outputs.version }}-macos.tar.gz \
-            vibecare-server VibeCare.app
+          tar -czf ../build/vibecare-${{ steps.version.outputs.version }}-macos.tar.gz VibeCare.app
           cd ..
           shasum -a 256 build/vibecare-${{ steps.version.outputs.version }}-macos.tar.gz \
             > build/vibecare-${{ steps.version.outputs.version }}-macos.tar.gz.sha256

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -27,6 +27,10 @@ import (
 	"google.golang.org/grpc/reflection"
 )
 
+// version is the build version, overridden at build time via
+// `-ldflags "-X main.version=$VERSION"`.
+var version = "dev"
+
 // initLogger creates a zap logger with configurable level and format
 func initLogger(levelFlag, formatFlag string) (*zap.Logger, error) {
 	// Environment variables take precedence over flags
@@ -84,6 +88,7 @@ func main() {
 		log.Fatalf("Failed to initialize logger: %v", err)
 	}
 	defer logger.Sync()
+	logger.Info("VibeCare backend version", zap.String("version", version))
 
 	// Initialize OpenTelemetry tracing
 	var shutdownTracer func(context.Context) error
@@ -190,7 +195,7 @@ func main() {
 	httpTracer := telemetry.GetTracer("vibecare.http.server")
 
 	// Initialize and start web server with OpenTelemetry instrumentation
-	webServer := web.NewServer(*webPort, db, sched, mcpServer, iconLoader, httpTracer, logger)
+	webServer := web.NewServer(*webPort, db, sched, mcpServer, iconLoader, httpTracer, logger, version)
 	go func() {
 		if err := webServer.Start(); err != nil {
 			logger.Error("Web server failed", zap.Error(err))

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -64,6 +64,27 @@ func initLogger(levelFlag, formatFlag string) (*zap.Logger, error) {
 	// Set the log level
 	config.Level = zap.NewAtomicLevelAt(level)
 
+	// Also write logs to ~/.vibecare/logs/server.log. This is done
+	// server-side (rather than via the LaunchAgent plist's StandardOutPath)
+	// because launchd does not expand "~" in plist paths, and resolving it
+	// here keeps behavior identical across the bundled LaunchAgent and
+	// `just run`/direct invocation on any OS. stderr is kept in
+	// OutputPaths/ErrorOutputPaths so console output is unaffected; if the
+	// log directory can't be created, we degrade gracefully to stderr-only
+	// instead of failing startup.
+	if home, err := os.UserHomeDir(); err == nil {
+		logDir := filepath.Join(home, ".vibecare", "logs")
+		if err := os.MkdirAll(logDir, 0o755); err != nil {
+			log.Printf("Failed to create log directory %q, logging to stderr only: %v", logDir, err)
+		} else {
+			logFile := filepath.Join(logDir, "server.log")
+			config.OutputPaths = append(config.OutputPaths, logFile)
+			config.ErrorOutputPaths = append(config.ErrorOutputPaths, logFile)
+		}
+	} else {
+		log.Printf("Failed to resolve home directory, logging to stderr only: %v", err)
+	}
+
 	// Build and return logger
 	return config.Build()
 }

--- a/backend/internal/web/server.go
+++ b/backend/internal/web/server.go
@@ -2,6 +2,7 @@ package web
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/pprof"
@@ -18,12 +19,13 @@ import (
 // Server represents the HTTP server for the web dashboard
 type Server struct {
 	httpServer *http.Server
+	mux        *http.ServeMux
 	logger     *zap.Logger
 	tracer     trace.Tracer
 }
 
 // NewServer creates a new web server with OpenTelemetry instrumentation
-func NewServer(port int, db *storage.DB, sched *scheduler.Scheduler, mcpServer *mcp.Server, iconLoader IconDataGetter, tracer trace.Tracer, logger *zap.Logger) *Server {
+func NewServer(port int, db *storage.DB, sched *scheduler.Scheduler, mcpServer *mcp.Server, iconLoader IconDataGetter, tracer trace.Tracer, logger *zap.Logger, version string) *Server {
 	handler := NewHandler(db, sched, mcpServer, logger)
 
 	mux := http.NewServeMux()
@@ -48,6 +50,15 @@ func NewServer(port int, db *storage.DB, sched *scheduler.Scheduler, mcpServer *
 
 		return handler
 	}
+
+	// Version endpoint — reports the running server's build version so
+	// clients can detect a stale/older backend. Intentionally independent
+	// of db/sched/mcp so it works even when those are nil.
+	versionHandler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"version": version})
+	}
+	mux.Handle("/version", applyMiddleware(versionHandler, "version"))
 
 	// Register handlers with full middleware stack
 	mux.Handle("/status", applyMiddleware(handler.DashboardHandler, "dashboard_page"))
@@ -89,9 +100,16 @@ func NewServer(port int, db *storage.DB, sched *scheduler.Scheduler, mcpServer *
 			WriteTimeout: 15 * time.Second,
 			IdleTimeout:  60 * time.Second,
 		},
+		mux:    mux,
 		logger: logger,
 		tracer: tracer,
 	}
+}
+
+// Handler exposes the server's mux directly, primarily for testing routes
+// without starting a real listener.
+func (s *Server) Handler() http.Handler {
+	return s.mux
 }
 
 // Start starts the HTTP server

--- a/backend/internal/web/version_test.go
+++ b/backend/internal/web/version_test.go
@@ -1,0 +1,34 @@
+package web
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+func TestVersionEndpoint(t *testing.T) {
+	// NewServer builds the mux; hit /version through the server's handler.
+	srv := NewServer(0, nil, nil, nil, nil, nil, zap.NewNop(), "v9.9.9")
+	req := httptest.NewRequest(http.MethodGet, "/version", nil)
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+	if ct := rr.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", ct)
+	}
+	var body struct {
+		Version string `json:"version"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if body.Version != "v9.9.9" {
+		t.Errorf("version = %q, want v9.9.9", body.Version)
+	}
+}

--- a/clients/macos-swift/VibeCare/VibeCare/App.swift
+++ b/clients/macos-swift/VibeCare/VibeCare/App.swift
@@ -32,6 +32,7 @@ struct VibeCareApp: App {
                 .onAppear {
                     // Load initial data
                     Task {
+                        await BackendManager.shared.ensureRunning()
                         await appState.loadInitialData()
 
                         // Auto-resume VibeCheck detection if it was on at last quit.

--- a/clients/macos-swift/VibeCare/VibeCare/ContentView.swift
+++ b/clients/macos-swift/VibeCare/VibeCare/ContentView.swift
@@ -12,7 +12,42 @@ struct ContentView: View {
         case .failed(let message):
             failedContent(message: message)
         case .ready:
-            readyContent
+            VStack(spacing: 0) {
+                if backend.backendStale {
+                    backendStaleBanner
+                }
+                readyContent
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var backendStaleBanner: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "arrow.triangle.2.circlepath.circle.fill")
+                .foregroundStyle(.orange)
+            Text("A new version is installed — restart the backend to apply it.")
+                .font(.subheadline)
+                .lineLimit(2)
+            Spacer()
+            if backend.state == .starting {
+                ProgressView()
+                    .controlSize(.small)
+            } else {
+                Button("Restart") {
+                    Task {
+                        await backend.restart()
+                    }
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.small)
+            }
+        }
+        .padding(.horizontal)
+        .padding(.vertical, 8)
+        .background(Color.orange.opacity(0.15))
+        .overlay(alignment: .bottom) {
+            Divider()
         }
     }
 

--- a/clients/macos-swift/VibeCare/VibeCare/ContentView.swift
+++ b/clients/macos-swift/VibeCare/VibeCare/ContentView.swift
@@ -3,8 +3,55 @@ import SwiftUI
 struct ContentView: View {
     @EnvironmentObject private var appState: AppState
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+    @StateObject private var backend = BackendManager.shared
 
     var body: some View {
+        switch backend.state {
+        case .starting:
+            startingContent
+        case .failed(let message):
+            failedContent(message: message)
+        case .ready:
+            readyContent
+        }
+    }
+
+    @ViewBuilder
+    private var startingContent: some View {
+        VStack(spacing: 16) {
+            ProgressView()
+            Text("Starting VibeCare…")
+                .font(.headline)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    @ViewBuilder
+    private func failedContent(message: String) -> some View {
+        VStack(spacing: 16) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.largeTitle)
+                .foregroundStyle(.orange)
+            Text(message)
+                .font(.headline)
+                .multilineTextAlignment(.center)
+            Button("Retry") {
+                Task {
+                    await backend.ensureRunning()
+                }
+            }
+            .buttonStyle(.borderedProminent)
+            Text("See ~/.vibecare/logs/server.log")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .padding()
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    @ViewBuilder
+    private var readyContent: some View {
         Group {
             if horizontalSizeClass == .compact {
                 CompactDashboard()

--- a/clients/macos-swift/VibeCare/VibeCare/Services/Backend/BackendManager.swift
+++ b/clients/macos-swift/VibeCare/VibeCare/Services/Backend/BackendManager.swift
@@ -1,0 +1,84 @@
+import Foundation
+import SwiftUI
+
+extension Bundle {
+    var appVersion: String { infoDictionary?["CFBundleShortVersionString"] as? String ?? "dev" }
+}
+
+@MainActor
+final class BackendManager: ObservableObject {
+    static let shared = BackendManager()
+
+    enum State: Equatable { case starting, ready, failed(String) }
+    @Published var state: State = .starting
+    @Published var backendVersion: String?
+    @Published var backendStale = false
+
+    private let supervisor: BackendSupervisor
+    private let appVersion: String
+    private let statusURL: URL
+    private let versionURL: URL
+
+    init(supervisor: BackendSupervisor = SMAppServiceSupervisor(),
+         appVersion: String = Bundle.main.appVersion,
+         statusURL: URL = URL(string: "http://localhost:8080/status")!,
+         versionURL: URL = URL(string: "http://localhost:8080/version")!) {
+        self.supervisor = supervisor
+        self.appVersion = appVersion
+        self.statusURL = statusURL
+        self.versionURL = versionURL
+    }
+
+    /// Pure, testable: backend is stale iff it reports a version that differs
+    /// from the app's own. Unknown (nil) backend version is NOT stale.
+    nonisolated static func isStale(appVersion: String, backendVersion: String?) -> Bool {
+        guard let b = backendVersion else { return false }
+        return b != appVersion
+    }
+
+    func ensureRunning() async {
+        state = .starting
+        do { try supervisor.ensureRegistered() }
+        catch { /* fall through — maybe already running via `just run` */ }
+        if await waitForHealthy(timeout: 15) {
+            backendVersion = await probeVersion()
+            backendStale = Self.isStale(appVersion: appVersion, backendVersion: backendVersion)
+            state = .ready
+        } else {
+            state = .failed("The VibeCare backend didn't start. Check ~/.vibecare/logs/server.log.")
+        }
+    }
+
+    func restart() async {
+        state = .starting
+        try? supervisor.restart()
+        if await waitForHealthy(timeout: 15) {
+            backendVersion = await probeVersion()
+            backendStale = Self.isStale(appVersion: appVersion, backendVersion: backendVersion)
+            state = .ready
+        } else {
+            state = .failed("Backend failed to restart.")
+        }
+    }
+
+    private func waitForHealthy(timeout: TimeInterval) async -> Bool {
+        let deadline = ContinuousClock.now.advanced(by: .seconds(timeout))
+        while ContinuousClock.now < deadline {
+            if await probeHealthy() { return true }
+            try? await Task.sleep(for: .milliseconds(400))
+        }
+        return false
+    }
+    private func probeHealthy() async -> Bool {
+        var req = URLRequest(url: statusURL); req.timeoutInterval = 2
+        if let (_, resp) = try? await URLSession.shared.data(for: req),
+           let http = resp as? HTTPURLResponse { return http.statusCode == 200 }
+        return false
+    }
+    private func probeVersion() async -> String? {
+        var req = URLRequest(url: versionURL); req.timeoutInterval = 2
+        guard let (data, _) = try? await URLSession.shared.data(for: req),
+              let obj = try? JSONDecoder().decode([String:String].self, from: data) else { return nil }
+        return obj["version"]
+    }
+}

--- a/clients/macos-swift/VibeCare/VibeCare/Services/Backend/BackendManager.swift
+++ b/clients/macos-swift/VibeCare/VibeCare/Services/Backend/BackendManager.swift
@@ -36,6 +36,17 @@ final class BackendManager: ObservableObject {
         return b != appVersion
     }
 
+    /// Pure, testable: should the app silently restart a stale backend?
+    nonisolated static func shouldAutoRestart(stale: Bool, autoReloadEnabled: Bool) -> Bool {
+        stale && autoReloadEnabled
+    }
+
+    /// Persisted user preference — "Automatically restart backend after an update".
+    /// Defaults to true when unset.
+    var autoReloadEnabled: Bool {
+        UserDefaults.standard.object(forKey: "backend.autoReload") as? Bool ?? true
+    }
+
     func ensureRunning() async {
         state = .starting
         do { try supervisor.ensureRegistered() }
@@ -44,6 +55,9 @@ final class BackendManager: ObservableObject {
             backendVersion = await probeVersion()
             backendStale = Self.isStale(appVersion: appVersion, backendVersion: backendVersion)
             state = .ready
+            if Self.shouldAutoRestart(stale: backendStale, autoReloadEnabled: autoReloadEnabled) {
+                await restart()
+            }
         } else {
             state = .failed("The VibeCare backend didn't start. Check ~/.vibecare/logs/server.log.")
         }

--- a/clients/macos-swift/VibeCare/VibeCare/Services/Backend/BackendManager.swift
+++ b/clients/macos-swift/VibeCare/VibeCare/Services/Backend/BackendManager.swift
@@ -31,6 +31,10 @@ final class BackendManager: ObservableObject {
 
     /// Pure, testable: backend is stale iff it reports a version that differs
     /// from the app's own. Unknown (nil) backend version is NOT stale.
+    /// A nil version covers a pre-`/version` daemon (404) or an unreachable
+    /// backend; treating it as "not stale" is deliberate — recovery for that
+    /// case relies on the cask's `kickstart` postflight + migration guidance,
+    /// not on this staleness check.
     nonisolated static func isStale(appVersion: String, backendVersion: String?) -> Bool {
         guard let b = backendVersion else { return false }
         return b != appVersion

--- a/clients/macos-swift/VibeCare/VibeCare/Services/Backend/BackendSupervisor.swift
+++ b/clients/macos-swift/VibeCare/VibeCare/Services/Backend/BackendSupervisor.swift
@@ -1,0 +1,17 @@
+import Foundation
+import ServiceManagement
+
+protocol BackendSupervisor {
+    func ensureRegistered() throws
+    func restart() throws
+    func isRegistered() -> Bool
+}
+
+/// macOS conformer: a bundled user LaunchAgent managed via SMAppService.
+/// (Linux/Windows conformers to follow — see the design's cross-platform note.)
+struct SMAppServiceSupervisor: BackendSupervisor {
+    private var agent: SMAppService { SMAppService.agent(plistName: "io.vibecare.server.plist") }
+    func isRegistered() -> Bool { agent.status == .enabled }
+    func ensureRegistered() throws { if agent.status != .enabled { try agent.register() } }
+    func restart() throws { try? agent.unregister(); try agent.register() }
+}

--- a/clients/macos-swift/VibeCare/VibeCare/Views/Settings/SettingsDetail.swift
+++ b/clients/macos-swift/VibeCare/VibeCare/Views/Settings/SettingsDetail.swift
@@ -305,14 +305,29 @@ struct ProfileSettingsDetail: View {
 }
 
 struct GeneralSettingsDetail: View {
+  @AppStorage("backend.autoReload") private var autoReloadBackend: Bool = true
+
   var body: some View {
-    VStack(alignment: .leading, spacing: 12) {
+    VStack(alignment: .leading, spacing: 20) {
       Text("General Settings")
         .font(.headline)
 
-      // Add general settings controls here
-      Text("General settings will be configured here")
-        .foregroundColor(.secondary)
+      VStack(alignment: .leading, spacing: 12) {
+        Text("Backend")
+          .font(.subheadline)
+          .foregroundColor(.secondary)
+
+        Toggle(isOn: $autoReloadBackend) {
+          VStack(alignment: .leading, spacing: 4) {
+            Text("Automatically restart backend after an update")
+              .font(.body)
+            Text("When the app updates, silently restart the backend instead of prompting.")
+              .font(.caption)
+              .foregroundColor(.secondary)
+          }
+        }
+        .toggleStyle(.switch)
+      }
     }
   }
 }

--- a/clients/macos-swift/VibeCare/vibecareTests/BackendManagerTests.swift
+++ b/clients/macos-swift/VibeCare/vibecareTests/BackendManagerTests.swift
@@ -1,0 +1,13 @@
+import Testing
+@testable import vibecare
+
+@Test func staleWhenBackendOlderOrDifferent() {
+    #expect(BackendManager.isStale(appVersion: "v0.8.7.26", backendVersion: "v0.8.7.26") == false)
+    #expect(BackendManager.isStale(appVersion: "v0.8.7.26", backendVersion: "v0.8.7.25") == true)
+    #expect(BackendManager.isStale(appVersion: "v0.8.7.26", backendVersion: "v0.8.7.26-dirty") == true)
+}
+
+@Test func notStaleWhenBackendVersionUnknown() {
+    // Unknown backend version (not yet probed / offline) is not "stale" — it's just unknown.
+    #expect(BackendManager.isStale(appVersion: "v0.8.7.26", backendVersion: nil) == false)
+}

--- a/clients/macos-swift/VibeCare/vibecareTests/BackendManagerTests.swift
+++ b/clients/macos-swift/VibeCare/vibecareTests/BackendManagerTests.swift
@@ -11,3 +11,15 @@ import Testing
     // Unknown backend version (not yet probed / offline) is not "stale" — it's just unknown.
     #expect(BackendManager.isStale(appVersion: "v0.8.7.26", backendVersion: nil) == false)
 }
+
+@Test func autoRestartsWhenStaleAndEnabled() {
+    #expect(BackendManager.shouldAutoRestart(stale: true, autoReloadEnabled: true) == true)
+}
+
+@Test func doesNotAutoRestartWhenStaleButDisabled() {
+    #expect(BackendManager.shouldAutoRestart(stale: true, autoReloadEnabled: false) == false)
+}
+
+@Test func doesNotAutoRestartWhenNotStale() {
+    #expect(BackendManager.shouldAutoRestart(stale: false, autoReloadEnabled: true) == false)
+}

--- a/docs/superpowers/plans/2026-08-10-self-managing-backend.md
+++ b/docs/superpowers/plans/2026-08-10-self-managing-backend.md
@@ -1,0 +1,483 @@
+# Self-Managing Bundled Backend + Update-Reload — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** The macOS app brings up its own `vibecare-server` backend on launch via an `SMAppService` LaunchAgent (fixing the cask-install hang), and surfaces a "backend is older than the app — restart to apply" control (with auto-reload) so a `brew upgrade` reloads the daemon.
+
+**Architecture:** Backend gains a `/version` endpoint. CI embeds the signed server + a LaunchAgent plist inside `VibeCare.app`, signed as one bundle. A Swift `BackendManager` registers the agent (`SMAppService`), health-gates startup on `/status`, reads `/version`, compares to the app's own version for staleness, and can restart the agent. The cask installs the app only and kicks the service on upgrade.
+
+**Tech Stack:** Go (net/http), GitHub Actions + codesign, SwiftUI + ServiceManagement (`SMAppService`), Homebrew cask. Backend tests `just test`; client tests xcodebuild; app build `just swift-build`.
+
+## Global Constraints
+
+- Do **not** edit `VCStubs/` or `backend/pkg/proto/` (generated). No proto changes.
+- Backend is **not** root; binds `localhost:50051`/`:8080`, DB `~/.vibecare`. Use a **user** `SMAppService.agent` (no admin prompt, no `SMJobBless`).
+- Keep the OS-agnostic contract per the spec's cross-platform note: `BackendManager` owns health/`/version`/staleness/UI; a `BackendSupervisor` protocol wraps the macOS `SMAppService` piece so Linux (systemd user) / Windows conformers can be added later. Server flags `--port/--web-port/--db`, and the `/version`+`/status` contract, stay identical across platforms.
+- App is `LSUIElement` (agent/menu-bar), not sandboxed; macOS 15+ (SMAppService available).
+- LaunchAgent label MUST be `io.vibecare.server` (matches the old plist + the cask kickstart). Server args `--port 50051 --web-port 8080`.
+- The app's own version = `Bundle.main.infoDictionary["CFBundleShortVersionString"]`; the release sets it (and `main.version`) to the release version string.
+- ⚠️ Case-insensitive FS: client sources on disk lowercase `.../vibecare/…`, git-tracked capital `.../VibeCare/VibeCare/…`. `git add` + verify `git status`.
+- Tests: Go `just test` / `go test ./...`; swift-testing whole target (`xcodebuild test … -only-testing:vibecareTests`); `just swift-build`.
+- Paths: backend relative to repo root; client relative to `clients/macos-swift/VibeCare/`.
+
+---
+
+## Phase A — self-starting bundled backend (fixes the hang)
+
+### Task A1: Backend `/version` endpoint (TDD)
+
+**Files:**
+- Modify: `backend/cmd/server/main.go` (add `var version`, pass to web server)
+- Modify: `backend/internal/web/server.go` (`NewServer` gains `version string`; register `/version`)
+- Modify: `backend/cmd/server/main.go:193` call site
+- Test: `backend/internal/web/version_test.go`
+
+**Interfaces:**
+- `NewServer(port int, db *storage.DB, sched *scheduler.Scheduler, mcpServer *mcp.Server, iconLoader IconDataGetter, tracer trace.Tracer, logger *zap.Logger, version string) *Server` — new trailing `version` param.
+- `GET /version` → `200`, `Content-Type: application/json`, body `{"version":"<version>"}`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/internal/web/version_test.go`:
+
+```go
+package web
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+func TestVersionEndpoint(t *testing.T) {
+	// NewServer builds the mux; hit /version through the server's handler.
+	srv := NewServer(0, nil, nil, nil, nil, nil, zap.NewNop(), "v9.9.9")
+	req := httptest.NewRequest(http.MethodGet, "/version", nil)
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+	if ct := rr.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", ct)
+	}
+	var body struct{ Version string `json:"version"` }
+	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if body.Version != "v9.9.9" {
+		t.Errorf("version = %q, want v9.9.9", body.Version)
+	}
+}
+```
+
+> This assumes a `Server.Handler() http.Handler` accessor exposing the mux for testing. If `Server` has no such accessor, add one: store the `mux` on `Server` in `NewServer` and add `func (s *Server) Handler() http.Handler { return s.mux }`. The `/version` handler must not require db/sched/mcp (pass `nil` in the test) — register it as a plain handler independent of `NewHandler`.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd backend && go test ./internal/web/ -run TestVersionEndpoint`
+Expected: FAIL — `/version` returns 404 / `NewServer` arity mismatch / no `Handler()`.
+
+- [ ] **Step 3: Implement**
+
+In `server.go`: add `version string` as the last `NewServer` param; store the `mux` on `Server` (add a `mux *http.ServeMux` field, assign it, and `func (s *Server) Handler() http.Handler { return s.mux }`); register the version route (no middleware needed, but wrapping with `applyMiddleware` is fine):
+
+```go
+	versionHandler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"version": version})
+	}
+	mux.Handle("/version", applyMiddleware(versionHandler, "version"))
+```
+(add `"encoding/json"` import.)
+
+In `main.go`: add package-level `var version = "dev"` (overridden by `-ldflags "-X main.version=…"`), log it at startup, and pass `version` as the new last arg at `web.NewServer(...)` (line ~193).
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd backend && go test ./internal/web/ -run TestVersionEndpoint -v`
+Expected: PASS.
+
+- [ ] **Step 5: Full backend test + build**
+
+Run: `just test` (or `go test ./...`) and `just build`. Expected: green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/cmd/server/main.go backend/internal/web/server.go backend/internal/web/version_test.go
+git commit -m "feat(backend): /version endpoint reporting the build version"
+```
+
+---
+
+### Task A2: Embed signed server + LaunchAgent plist into the app bundle (CI)
+
+**Files:**
+- Create: `.github/scripts/io.vibecare.server.agent.plist` (SMAppService LaunchAgent template) — or generate inline
+- Modify: `.github/workflows/release.yml` (`build-macos-client`: `needs: build-backend`, download server, embed + plist, sign once; `create-release`: tarball app-only)
+
+**Interfaces:** Produces a `VibeCare.app` containing `Contents/Resources/vibecare-server` and `Contents/Library/LaunchAgents/io.vibecare.server.plist`, signed as one bundle. The tarball ships only `VibeCare.app`.
+
+- [ ] **Step 1: Add the LaunchAgent plist**
+
+Create `.github/scripts/io.vibecare.server.plist` (SMAppService agent format):
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>io.vibecare.server</string>
+    <key>BundleProgram</key>
+    <string>Contents/Resources/vibecare-server</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>Contents/Resources/vibecare-server</string>
+        <string>--port</string><string>50051</string>
+        <string>--web-port</string><string>8080</string>
+    </array>
+    <key>RunAtLoad</key><true/>
+    <key>KeepAlive</key>
+    <dict><key>SuccessfulExit</key><false/></dict>
+    <key>ProcessType</key><string>Background</string>
+</dict>
+</plist>
+```
+
+> Verify against Apple's current `SMAppService` LaunchAgent rules: `BundleProgram` is the executable path relative to the app bundle; `ProgramArguments[0]` should be that same path (args follow). If the launchd job fails to find the program, this is the thing to adjust (documented in the report). Logs go to `~/.vibecare/logs/` — the server creates that dir; if not, add `StandardOutPath`/`StandardErrorPath` with an absolute path resolved at runtime (server already logs to `~/.vibecare/logs/`).
+
+- [ ] **Step 2: Wire embedding + single signing into `build-macos-client`**
+
+In `release.yml` `build-macos-client`: add `needs: build-backend`; after "Create app bundle" and **before** "Sign app bundle", add steps to download the backend artifact and embed it + the plist:
+
+```yaml
+      - name: Download backend artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: backend-binary
+          path: .
+      - name: Embed server + LaunchAgent into app bundle
+        run: |
+          tar -xvf backend-binary.tar
+          mkdir -p VibeCare.app/Contents/Resources VibeCare.app/Contents/Library/LaunchAgents
+          cp vibecare-server VibeCare.app/Contents/Resources/vibecare-server
+          chmod +x VibeCare.app/Contents/Resources/vibecare-server
+          cp .github/scripts/io.vibecare.server.plist \
+             VibeCare.app/Contents/Library/LaunchAgents/io.vibecare.server.plist
+```
+
+`sign-app-bundle` already uses `codesign --deep`, so the nested `vibecare-server` gets signed by the same identity when the bundle is signed. Keep the existing sign step after this. (`build-backend` already signs the server too; re-signing under `--deep` with the same identity is fine.)
+
+- [ ] **Step 3: `create-release` tarball becomes app-only**
+
+In `create-release`, the app already contains the server. Change the "Create tarball" step to package just the app (the server is inside):
+
+```yaml
+          tar -czf ../build/vibecare-${{ steps.version.outputs.version }}-macos.tar.gz VibeCare.app
+```
+(Remove the separate top-level `vibecare-server` from the tarball. Keep the `.sha256` line.) The backend-binary download/extract steps in `create-release` that placed `dist/vibecare-server` are no longer needed for the tarball, but leaving them is harmless; simplest is to keep `dist/VibeCare.app` handling and tarball only the app.
+
+- [ ] **Step 4: Validate the workflow YAML**
+
+Run: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml')); print('YAML OK')"`
+Expected: `YAML OK`. (Signing/embedding correctness is verified by a real release build + manual run — see Phase C.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .github/scripts/io.vibecare.server.plist .github/workflows/release.yml
+git commit -m "ci(release): embed signed vibecare-server + LaunchAgent into VibeCare.app"
+```
+
+---
+
+### Task A3: `BackendManager` + `BackendSupervisor` (SMAppService), staleness logic (TDD)
+
+**Files:**
+- Create: `vibecare/Services/Backend/BackendSupervisor.swift` (protocol + `SMAppServiceSupervisor`)
+- Create: `vibecare/Services/Backend/BackendManager.swift`
+- Test: `vibecareTests/BackendManagerTests.swift`
+
+**Interfaces:**
+- `protocol BackendSupervisor { func ensureRegistered() throws; func restart() throws; func isRegistered() -> Bool }`
+- `struct SMAppServiceSupervisor: BackendSupervisor` — wraps `SMAppService.agent(plistName: "io.vibecare.server.plist")` (`register`/`unregister`+`register`/`status`).
+- `@MainActor final class BackendManager: ObservableObject` with `static let shared`, `enum State { case starting, ready, failed(String) }`, `@Published var state`, `@Published var backendVersion: String?`, `@Published var backendStale: Bool`, `func ensureRunning() async`, `func restart() async`, and a **pure static** `static func isStale(appVersion: String, backendVersion: String?) -> Bool`.
+- `init(supervisor: BackendSupervisor = SMAppServiceSupervisor(), appVersion: String = Bundle.main.appVersion, statusURL:…, versionURL:…)` — injectable for tests.
+
+- [ ] **Step 1: Write the failing tests (pure staleness logic)**
+
+Create `vibecareTests/BackendManagerTests.swift`:
+
+```swift
+import Testing
+@testable import vibecare
+
+@Test func staleWhenBackendOlderOrDifferent() {
+    #expect(BackendManager.isStale(appVersion: "v0.8.7.26", backendVersion: "v0.8.7.26") == false)
+    #expect(BackendManager.isStale(appVersion: "v0.8.7.26", backendVersion: "v0.8.7.25") == true)
+    #expect(BackendManager.isStale(appVersion: "v0.8.7.26", backendVersion: "v0.8.7.26-dirty") == true)
+}
+
+@Test func notStaleWhenBackendVersionUnknown() {
+    // Unknown backend version (not yet probed / offline) is not "stale" — it's just unknown.
+    #expect(BackendManager.isStale(appVersion: "v0.8.7.26", backendVersion: nil) == false)
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd clients/macos-swift/VibeCare && xcodebuild test -project vibecare.xcodeproj -scheme vibecare -destination 'platform=macOS' -only-testing:vibecareTests 2>&1 | tail -20`
+Expected: FAIL — `BackendManager` undefined.
+
+- [ ] **Step 3: Implement the supervisor + manager**
+
+Create `BackendSupervisor.swift`:
+
+```swift
+import Foundation
+import ServiceManagement
+
+protocol BackendSupervisor {
+    func ensureRegistered() throws
+    func restart() throws
+    func isRegistered() -> Bool
+}
+
+/// macOS conformer: a bundled user LaunchAgent managed via SMAppService.
+/// (Linux/Windows conformers to follow — see the design's cross-platform note.)
+struct SMAppServiceSupervisor: BackendSupervisor {
+    private var agent: SMAppService { SMAppService.agent(plistName: "io.vibecare.server.plist") }
+    func isRegistered() -> Bool { agent.status == .enabled }
+    func ensureRegistered() throws { if agent.status != .enabled { try agent.register() } }
+    func restart() throws { try? agent.unregister(); try agent.register() }
+}
+```
+
+Create `BackendManager.swift`:
+
+```swift
+import Foundation
+import SwiftUI
+
+extension Bundle {
+    var appVersion: String { infoDictionary?["CFBundleShortVersionString"] as? String ?? "dev" }
+}
+
+@MainActor
+final class BackendManager: ObservableObject {
+    static let shared = BackendManager()
+
+    enum State: Equatable { case starting, ready, failed(String) }
+    @Published var state: State = .starting
+    @Published var backendVersion: String?
+    @Published var backendStale = false
+
+    private let supervisor: BackendSupervisor
+    private let appVersion: String
+    private let statusURL: URL
+    private let versionURL: URL
+
+    init(supervisor: BackendSupervisor = SMAppServiceSupervisor(),
+         appVersion: String = Bundle.main.appVersion,
+         statusURL: URL = URL(string: "http://localhost:8080/status")!,
+         versionURL: URL = URL(string: "http://localhost:8080/version")!) {
+        self.supervisor = supervisor
+        self.appVersion = appVersion
+        self.statusURL = statusURL
+        self.versionURL = versionURL
+    }
+
+    /// Pure, testable: backend is stale iff it reports a version that differs
+    /// from the app's own. Unknown (nil) backend version is NOT stale.
+    static func isStale(appVersion: String, backendVersion: String?) -> Bool {
+        guard let b = backendVersion else { return false }
+        return b != appVersion
+    }
+
+    func ensureRunning() async {
+        state = .starting
+        do { try supervisor.ensureRegistered() }
+        catch { /* fall through — maybe already running via `just run` */ }
+        if await waitForHealthy(timeout: 15) {
+            backendVersion = await probeVersion()
+            backendStale = Self.isStale(appVersion: appVersion, backendVersion: backendVersion)
+            state = .ready
+        } else {
+            state = .failed("The VibeCare backend didn't start. Check ~/.vibecare/logs/server.log.")
+        }
+    }
+
+    func restart() async {
+        state = .starting
+        try? supervisor.restart()
+        if await waitForHealthy(timeout: 15) {
+            backendVersion = await probeVersion()
+            backendStale = Self.isStale(appVersion: appVersion, backendVersion: backendVersion)
+            state = .ready
+        } else {
+            state = .failed("Backend failed to restart.")
+        }
+    }
+
+    private func waitForHealthy(timeout: TimeInterval) async -> Bool {
+        let deadline = ContinuousClock.now.advanced(by: .seconds(timeout))
+        while ContinuousClock.now < deadline {
+            if await probeHealthy() { return true }
+            try? await Task.sleep(for: .milliseconds(400))
+        }
+        return false
+    }
+    private func probeHealthy() async -> Bool {
+        var req = URLRequest(url: statusURL); req.timeoutInterval = 2
+        if let (_, resp) = try? await URLSession.shared.data(for: req),
+           let http = resp as? HTTPURLResponse { return http.statusCode == 200 }
+        return false
+    }
+    private func probeVersion() async -> String? {
+        var req = URLRequest(url: versionURL); req.timeoutInterval = 2
+        guard let (data, _) = try? await URLSession.shared.data(for: req),
+              let obj = try? JSONDecoder().decode([String:String].self, from: data) else { return nil }
+        return obj["version"]
+    }
+}
+```
+
+- [ ] **Step 4: Run tests → GREEN**
+
+Run: `cd clients/macos-swift/VibeCare && xcodebuild test -project vibecare.xcodeproj -scheme vibecare -destination 'platform=macOS' -only-testing:vibecareTests 2>&1 | grep -E "TEST SUCCEEDED|TEST FAILED|error:"`
+Expected: `** TEST SUCCEEDED **` (the 2 staleness tests pass; existing tests unaffected).
+
+- [ ] **Step 5: Build + commit**
+
+Run: `just swift-build`. Then:
+```bash
+git add clients/macos-swift/VibeCare/VibeCare/Services/Backend/BackendSupervisor.swift \
+        clients/macos-swift/VibeCare/VibeCare/Services/Backend/BackendManager.swift \
+        clients/macos-swift/VibeCare/vibecareTests/BackendManagerTests.swift
+git status
+git commit -m "feat(client): BackendManager + SMAppService supervisor (health-gate, version, staleness)"
+```
+
+---
+
+### Task A4: Startup wiring + launching/error UI
+
+**Files:**
+- Modify: `vibecare/App.swift` (root startup Task)
+- Modify: the root content view (e.g. `vibecare/Views/ContentView.swift` — the view rendered at startup) to gate on `BackendManager.state`
+
+**Interfaces:** Consumes `BackendManager.shared.ensureRunning()` / `.state`.
+
+- [ ] **Step 1: Ensure the backend before loading data**
+
+In `App.swift`'s startup `.onAppear { Task { … } }`, call `await BackendManager.shared.ensureRunning()` **before** `await appState.loadInitialData()`.
+
+- [ ] **Step 2: Gate the UI on backend state**
+
+In the root view, observe `@StateObject private var backend = BackendManager.shared` and switch on `backend.state`:
+- `.starting` → a centered "Starting VibeCare…" `ProgressView`.
+- `.failed(let msg)` → an error view with `msg` + a **Retry** button (`Task { await backend.ensureRunning() }`) + a hint to open `~/.vibecare/logs/server.log`.
+- `.ready` → the existing dashboard/content.
+
+(Read the current root view first and follow its structure; do not change unrelated layout.)
+
+- [ ] **Step 3: Build**
+
+Run: `just swift-build`. Expected: succeeds.
+
+- [ ] **Step 4: Run the full test target (no regressions)**
+
+Run: `cd clients/macos-swift/VibeCare && xcodebuild test -project vibecare.xcodeproj -scheme vibecare -destination 'platform=macOS' -only-testing:vibecareTests 2>&1 | grep -E "TEST SUCCEEDED|TEST FAILED|error:"`
+Expected: `** TEST SUCCEEDED **`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add clients/macos-swift/VibeCare/VibeCare/App.swift <root-view-path>
+git commit -m "feat(client): gate startup on backend readiness (starting/error UI)"
+```
+
+---
+
+### Task A5: Cask → app-only + tap update
+
+**Files:**
+- Modify (tap repo `vibecare-io/homebrew-apps`): `Casks/vibecare.rb`
+- Modify: `.github/workflows/release.yml` `update-homebrew-tap` job's cask template (PR #21 branch may still be open — coordinate; if merged, edit `main`)
+
+**Interfaces:** cask installs `app "VibeCare.app"` only (server embedded).
+
+- [ ] **Step 1: Drop the separate binary stanza**
+
+In the cask (both the live tap `Casks/vibecare.rb` and the workflow's generated template), remove `binary "vibecare-server"` (the server now lives inside the app and is launched by the LaunchAgent). Keep the quarantine-clear postflight and the `.pkg`-migration caveats.
+
+- [ ] **Step 2: Verify (once a build exists)**
+
+Deferred to Phase C after a real release: `brew audit --cask --strict` + `brew fetch`. For now, just make the edit consistent in both places and commit the workflow change.
+
+- [ ] **Step 3: Commit (workflow side)**
+
+```bash
+git add .github/workflows/release.yml
+git commit -m "ci(cask): install app only (server embedded in bundle)"
+```
+(Tap-repo edit is pushed directly to `vibecare-io/homebrew-apps` during Phase C when the release exists.)
+
+---
+
+## Phase B — update-available / restart-backend + auto-reload
+
+### Task B1: "Restart backend" banner + button
+
+**Files:**
+- Modify: root/content view (add a banner) or the dashboard toolbar
+- Consumes: `BackendManager.shared.backendStale`, `.restart()`
+
+- [ ] **Step 1:** When `backend.backendStale` is true, render a dismissible banner: **"A new version is installed — Restart backend to apply"** with a **Restart** button → `Task { await backend.restart() }`. While restarting, show progress; on success `backendStale` clears (versions match).
+- [ ] **Step 2:** Build (`just swift-build`) + full test target green.
+- [ ] **Step 3:** Commit `feat(client): backend-stale banner with Restart action`.
+
+### Task B2: Auto-reload setting
+
+**Files:**
+- Modify: `BackendManager` (read a `UserDefaults` flag `vibecheck… → "backend.autoReload"`, default true) and a Settings toggle in the app's Settings view.
+
+- [ ] **Step 1:** In `ensureRunning()`, after computing `backendStale`, if the persisted `autoReloadBackend` flag is true and `backendStale`, call `await restart()` automatically (so an upgraded app silently reloads the daemon). Expose the flag via a simple `AppStorage`/UserDefaults-backed toggle in Settings ("Automatically restart backend after an update").
+- [ ] **Step 2:** Add a focused test if the auto-decision is extracted as a pure function (`shouldAutoRestart(stale:enabled:) -> Bool`); else build + manual.
+- [ ] **Step 3:** Build + tests green. Commit `feat(client): auto-reload backend after update (setting)`.
+
+### Task B3: Cask `postflight` kickstart
+
+**Files:** tap `Casks/vibecare.rb` + workflow cask template.
+
+- [ ] **Step 1:** Add to the cask:
+```ruby
+  postflight do
+    system_command "/bin/launchctl",
+      args: ["kickstart", "-k", "gui/#{Process.uid}/io.vibecare.server"], sudo: false
+  end
+```
+(alongside the existing quarantine-clear postflight — combine into one `postflight do … end`). This restarts the daemon to the new binary on `brew upgrade`.
+- [ ] **Step 2:** `brew audit --cask --strict` once a build exists (Phase C). Commit the workflow template change; push the tap edit in Phase C.
+
+---
+
+## Phase C — verification + handoff
+
+- [ ] **Step 1:** Backend `just test` + `just build` green; client full test target + `just swift-build` green; `release.yml` YAML valid.
+- [ ] **Step 2:** Open a PR for the repo changes (backend + CI + client) → user merges → cut a release (`just release <next-version> main`) so a **signed bundle with the embedded server** exists.
+- [ ] **Step 3:** Update the tap cask (app-only + postflight) with the new tarball checksum; `brew audit --strict` + `brew fetch`.
+- [ ] **Step 4 (manual, user):** fresh `brew install --cask vibecare-io/apps/vibecare` → open app → **backend auto-starts, profiles load (no hang)**; app in Login Items. Quit app → backend keeps running (LaunchAgent); a due schedule still fires a reminder. Then `brew upgrade` to a newer build → cask kicks the service; open app → **no stale banner** (or, with auto-reload off, the banner appears and **Restart** applies it).
+- [ ] **Step 5:** Final scope check — only feature files committed; unrelated pre-existing working-tree changes (`VCStubs/*`, `docs-site/*`, `docs/backlog.org`, `docs/ideas.org`) not staged.
+
+## Notes / risks
+
+- **Verification is integration-heavy:** SMAppService registration, the embedded-binary signing, and the launchd job only exercise correctly in a **real signed release build** on a Mac — locally we cover the Go `/version` test, the Swift staleness unit tests, and both builds; the daemon lifecycle is proven by the Phase C manual run.
+- **SMAppService plist format** (BundleProgram + arguments) is the most likely thing to need a tweak; the plist is isolated in `.github/scripts/io.vibecare.server.plist` for easy iteration.
+- **Cross-platform:** `BackendSupervisor` isolates the macOS-only `SMAppService` code so Linux (systemd user) / Windows conformers slot in later without touching `BackendManager` (see the design doc + the `cross-platform-backend-supervisor` memory).

--- a/docs/superpowers/specs/2026-08-10-self-managing-backend-design.md
+++ b/docs/superpowers/specs/2026-08-10-self-managing-backend-design.md
@@ -1,0 +1,206 @@
+# Self-Managing Bundled Backend + Update-Reload — Design & Spec
+
+> Design doc. Date: 2026-08-10. Branch: TBD off `main`.
+> Spans: Go backend, macOS Swift client, release CI, Homebrew cask.
+> Self-contained for a fresh session.
+
+## Problem / Goal
+
+The Homebrew/tarball install ships `VibeCare.app` + `vibecare-server` but nothing
+starts the backend. Opening the app launches the Swift client, which can't reach
+the backend (gRPC `:50051` / HTTP `:8080`), so `listProfiles()` returns empty and
+the UI hangs on the "Select Profile / No profiles found" dialog (the old `.pkg`
+installed a LaunchAgent via `postinstall`; the cask has no such thing).
+
+**Goal:** the app brings up its own backend on launch — the macOS-native
+equivalent of a Docker/Tailscale "GUI + daemon". Use Apple's `SMAppService` to
+register a **bundled** `vibecare-server` LaunchAgent (no `.pkg`, no admin
+password, no root — the backend binds localhost and writes `~/.vibecare`). Then
+surface an in-app **"a new version is installed — restart backend to apply"**
+control (with an auto option) so a `brew upgrade` that swaps the app files also
+gets the running daemon onto the new binary.
+
+## Confirmed decisions (with the user)
+
+- **Model:** `SMAppService` **LaunchAgent** (user-level, always-on: `RunAtLoad` +
+  `KeepAlive`) — Tailscale-style always-on daemon, so scheduled reminders fire even
+  when the app window/menu-bar is closed. The server is **embedded in the app
+  bundle** so the `.app` is self-contained (cask installs only the app).
+- **Update-reload UX:** the client compares the running backend's version to its
+  own bundled version; when the backend is stale it shows a **"New version
+  installed — Restart backend"** banner/button, with a **Settings toggle to
+  auto-reload**. A cask `postflight` also kicks the service on `brew upgrade`.
+
+## Key facts (verified)
+
+- **Backend build already embeds the version:** `.github/scripts/build-universal-binary.sh`
+  builds with `-ldflags "-X main.version=$VERSION"`. But `backend/cmd/server/main.go`
+  has **no `version` var and no `/version` endpoint** — must be added.
+- **HTTP server** (`backend/internal/web/server.go`) registers routes on a `mux`
+  (e.g. `mux.Handle("/status", …)`). Add `/version` here (or in main). `/status`
+  returns 200 when up — usable as readiness. Server flags: `--port 50051
+  --web-port 8080 --db <path>` (db empty → default `~/.vibecare/vibecare.db`).
+  Server runs `goose.Up` migrations on startup (`backend/internal/storage/db.go`),
+  so launching the binary fully initializes the DB.
+- **App bundle:** `.github/scripts/create-app-bundle.sh` writes `Info.plist` with
+  `CFBundleShortVersionString`/`CFBundleVersion` = release version, and puts the app
+  binary at `Contents/MacOS/VibeCare`. It does **not** embed the server. Bundle id
+  `io.vibecare.app` (from CI) — note the Xcode project uses
+  `io.vibecare.App.vibecare`; the CI-built bundle uses `io.vibecare.app`.
+- **App is NOT sandboxed** (`vibecare.entitlements` has no
+  `com.apple.security.app-sandbox`), so it may register a `SMAppService.agent` and
+  the agent may spawn the server. `SMAppService` is macOS 13+; the app targets
+  macOS 15 — available.
+- **Client:** `AppState.loadInitialData()` calls `ProfileService.listProfiles()`;
+  on connection failure it returns empty → `showProfileSelector = true` (the hang).
+  `NetworkConfiguration` defaults: backend `http://localhost:8080`, gRPC
+  `grpc://localhost:50051`. The app reads its own version via
+  `Bundle.main.infoDictionary["CFBundleShortVersionString"]`.
+- **Release/cask (current):** `create-release` tarballs `vibecare-server` +
+  `VibeCare.app` side by side; cask installs `app "VibeCare.app"` + `binary
+  "vibecare-server"` (see `2026-08-08-vibecheck-default-icons` era work / the tap
+  `vibecare-io/homebrew-apps`).
+- ⚠️ Case-insensitive FS: client sources on disk at lowercase `.../vibecare/…`,
+  git-tracked under capital `.../VibeCare/VibeCare/…`. `git add` + verify with
+  `git status`.
+
+## Design
+
+### Phase A — self-starting bundled backend (fixes the hang)
+
+**A1. Backend `/version` endpoint.**
+- In `backend/cmd/server/main.go` declare `var version = "dev"` (overridden by the
+  existing ldflag `-X main.version=…`).
+- Register `GET /version` on the web mux returning JSON `{"version": "<version>"}`
+  (add in `web.Server` with the version passed in, or a small handler in main
+  wired into the mux). Log the version at startup.
+
+**A2. Embed the signed server + LaunchAgent plist into the app bundle (CI).**
+- Make `build-macos-client` depend on `build-backend`; download the signed
+  `vibecare-server` artifact; copy it to `VibeCare.app/Contents/Resources/vibecare-server`
+  **before** `sign-app-bundle`, and add
+  `VibeCare.app/Contents/Library/LaunchAgents/io.vibecare.server.plist`. Then sign
+  the whole bundle so the nested binary + plist are covered (sign nested code first
+  if needed, then the app). `create-release` tarballs the app (server inside); it
+  no longer ships a separate top-level `vibecare-server`.
+- **LaunchAgent plist** (`SMAppService` format): `Label = io.vibecare.server`,
+  `BundleProgram = Contents/Resources/vibecare-server`, arguments `--port 50051
+  --web-port 8080`, `RunAtLoad = true`, `KeepAlive` (restart on failure),
+  `StandardOut/ErrorPath = ~/.vibecare/logs/server.log`. (Implementer: follow
+  Apple's current `SMAppService` LaunchAgent plist rules for `BundleProgram` +
+  arguments; verify the launchd job runs the bundled binary.)
+
+**A3. Client `BackendManager` (new `@MainActor` service).**
+```
+final class BackendManager: ObservableObject {
+    static let shared
+    enum State { case unknown, starting, ready, failed(String) }
+    @Published var state: State
+    @Published var backendVersion: String?   // from /version once ready
+
+    // Registers the SMAppService agent if needed, then waits for readiness.
+    func ensureRunning() async
+    // Health probe: GET http://localhost:8080/status (short timeout) → up?
+    // Version probe: GET /version → backendVersion
+    // restart(): SMAppService.unregister() then register() (reloads plist+binary)
+}
+```
+- `ensureRunning()`: if `SMAppService.agent(plistName:).status` isn't enabled, call
+  `register()`. Poll `/status` until 200 (timeout ~15s, backoff). On success set
+  `.ready` and fetch `/version`. On timeout set `.failed(...)`.
+- If a backend is **already running** (dev `just run`, or a prior agent), `/status`
+  answers immediately → reuse; do not double-register/kill it beyond what
+  SMAppService idempotently manages.
+
+**A4. Startup wiring + UI (`App.swift`, root view).**
+- In the startup Task, `await BackendManager.shared.ensureRunning()` **before**
+  `appState.loadInitialData()`.
+- Root view shows a **"Starting VibeCare…"** state while `state == .starting`,
+  and a real **error + Retry** when `.failed` (instead of the misleading empty
+  profile selector). Only proceed to the normal dashboard when `.ready`.
+
+**A5. Cask (tap `vibecare-io/homebrew-apps`).**
+- Cask installs `app "VibeCare.app"` only (drop the separate `binary`, since the
+  server is embedded). Keep the quarantine-clear postflight.
+- The app itself registers/unregisters the agent (SMAppService); document in
+  caveats that quitting removes the login item is a future nicety.
+
+### Phase B — update-available / restart-backend + auto-reload
+
+**B1. Stale detection.** The app's own version = `CFBundleShortVersionString`. When
+`.ready`, compare `backendVersion` to the app version. If they differ (running
+backend older than the installed app — the post-`brew upgrade` case), set
+`@Published var backendStale = true` on `BackendManager`.
+
+**B2. UI.** When `backendStale`, show a banner/toolbar item: **"A new version is
+installed — Restart backend to apply"** with a **Restart** button → `await
+BackendManager.shared.restart()` (SMAppService unregister→register; then re-probe
+`/version`; clear `backendStale` when versions match).
+
+**B3. Auto-reload setting.** A Settings toggle `autoReloadBackend` (UserDefaults,
+default on). When on and `backendStale` is detected on launch, call `restart()`
+automatically instead of only showing the banner.
+
+**B4. Cask `postflight` reload.** Add to the cask:
+```ruby
+postflight do
+  system_command "/bin/launchctl",
+    args: ["kickstart", "-k", "gui/#{Process.uid}/io.vibecare.server"], sudo: false
+end
+```
+so `brew upgrade` restarts the daemon to the new binary immediately (best-effort;
+`|| true` semantics — ignore if not loaded). The app-side re-register (B2/B3)
+remains the robust path (also handles a changed plist). `KeepAlive` means any
+crash/reboot also brings up the new binary.
+
+## Cross-platform (future — Linux / Windows clients)
+
+This spec implements macOS. The **contract** must stay platform-agnostic so future
+clients reuse it; only the launcher/supervisor differs per OS. Design
+`BackendManager` around a small protocol:
+
+```
+protocol BackendSupervisor {           // one conformer per platform
+    func ensureRegistered() async throws // install/enable the OS service
+    func restart() async throws          // reload to the on-disk binary
+    func isRegistered() -> Bool
+}
+```
+`BackendManager` owns the OS-agnostic parts (health probe `/status`, `/version`
+fetch, staleness compare, state machine, UI signals); `BackendSupervisor` is the
+per-OS piece. The health/version endpoints and the "restart backend to apply an
+update" UX are identical everywhere — only how the daemon is supervised changes:
+
+| OS | Supervisor (Docker `restart:` equivalent) | Notes |
+|----|-------------------------------------------|-------|
+| **macOS** | `SMAppService` user **LaunchAgent** (this spec) | RunAtLoad + KeepAlive; no root |
+| **Linux** | **systemd user service** (`systemctl --user enable --now vibecare-server`) with `Restart=on-failure`; user unit installed under `~/.config/systemd/user/` | fall back to XDG autostart + app-spawned child if systemd absent |
+| **Windows** | app-managed child process + **Startup**/Task Scheduler registration, or a Windows Service (`sc`/`New-Service`) | service needs admin; prefer per-user Startup + app supervision |
+
+Keep the server flags (`--port/--web-port/--db`), the `/version` + `/status`
+contract, and the update-reload semantics identical across platforms so only the
+`BackendSupervisor` conformer is written per OS.
+
+## Testing
+
+- **Backend (Go, TDD):** test `GET /version` returns the injected version (set the
+  `version` var in the test or assert the default), and that it's valid JSON.
+- **Client (swift-testing, pure logic):** `BackendManager`'s version-staleness
+  comparison is a pure function — test `isStale(app:backend:)` (equal → false,
+  backend older/different → true, nil backend → not stale/unknown). The
+  SMAppService registration, subprocess, health-poll, and UI are integration —
+  verified by build + manual run.
+- **Manual run** (the real proof): fresh `brew install` → open app → backend
+  auto-starts, profiles load (no hang). Quit → (Phase A always-on) backend keeps
+  running; a scheduled reminder still fires. Simulate an upgrade (bump app version
+  / install newer) → banner appears → Restart applies it; toggle auto-reload.
+
+## Non-goals
+
+- No root LaunchDaemon / `SMJobBless` / privileged helper (backend needs no root).
+- No external appcast / "newer release on GitHub" check (Sparkle-style) — "update
+  available" here means the **running backend is older than the installed app**,
+  not that a newer release exists upstream. (Possible follow-up.)
+- No Docker/containerization for the shipped app.
+- No change to detection/notification features or the notarization decision.
+```


### PR DESCRIPTION
## Why
Cask/tarball installs ship `VibeCare.app` but nothing started the backend, so the client launched, couldn't reach `localhost:8080`/`:50051`, and hung on "No profiles found". The old `.pkg` fixed this with a `postinstall` LaunchAgent — the cask has none.

## What
The app now brings up its own backend on launch — the macOS-native equivalent of a Docker/Tailscale GUI+daemon, via Apple's `SMAppService` (a **bundled user LaunchAgent**, no root, no `.pkg`). Plus an in-app "backend is older than the app → Restart to apply" control with an auto-reload option, so a `brew upgrade` reloads the daemon.

- **Backend:** `GET /version` → `{"version":<build version>}`; logs to `~/.vibecare/logs/server.log`.
- **CI (`release.yml`):** `build-macos-client` embeds the signed `vibecare-server` + a LaunchAgent plist (`io.vibecare.server`) **inside** `VibeCare.app` before `codesign --deep`; tarball + cask are app-only; cask `postflight` clears quarantine and `launchctl kickstart`s the agent on upgrade.
- **Client:** `BackendManager` (behind a platform-agnostic `BackendSupervisor` — macOS uses `SMAppService`, Linux/Windows conformers later) registers the agent, health-gates on `/status`, reads `/version`, computes staleness, auto-restarts when stale+enabled (setting, default on). `App.swift` awaits `ensureRunning()` before loading data; `ContentView` shows Starting…/error+Retry instead of the empty profile dialog, plus a stale banner.

## Verification
Backend `go test ./...` + `go build` green; client full `vibecareTests` target `** TEST SUCCEEDED **` + `just swift-build` green; `release.yml` YAML valid; plist lints. Each task passed a review gate; a final whole-branch review confirmed the version / label-plist-filename / embed-before-sign contracts, loop safety, and default-true flag, and its findings were fixed.

⚠️ **Runtime is integration-only:** `SMAppService` registration, launchd running the daemon, the embedded-binary signature, and the no-hang launch only exercise in a **signed release build installed on a Mac** — that's the post-merge manual step (cut a release → `brew install` → confirm the backend auto-starts and profiles load).

Design/plan: `docs/superpowers/specs/2026-08-10-self-managing-backend-design.md`, `docs/superpowers/plans/2026-08-10-self-managing-backend.md`. Cross-platform (Linux systemd / Windows) supervisor path is documented for future clients.

🤖 Generated with [Claude Code](https://claude.com/claude-code)