### PR TITLE
fix(cask): best-effort backend kickstart (must_succeed: false)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -286,9 +286,14 @@ jobs:
               system_command "/usr/bin/xattr",
                              args: ["-dr", "com.apple.quarantine", "#{appdir}/VibeCare.app"],
                              sudo: false
+              # Best-effort: restart the backend only if its LaunchAgent is
+              # already loaded (from a prior app launch). On a fresh install the
+              # agent isn't registered yet (the app registers it via SMAppService
+              # on first launch), so this must NOT abort the install.
               system_command "/bin/launchctl",
                              args: ["kickstart", "-k", "gui/#{Process.uid}/io.vibecare.server"],
-                             sudo: false
+                             sudo: false,
+                             must_succeed: false
             end
 
             caveats <<~EOS


### PR DESCRIPTION
`brew upgrade --cask vibecare` failed and reverted because the postflight `launchctl kickstart -k gui/<uid>/io.vibecare.server` exits non-zero when the LaunchAgent isn't loaded yet (fresh install / pre-self-managing versions). The app registers the agent via `SMAppService` on first launch, so the postflight restart is only a nicety for an already-running daemon — it must not abort the install.

Adds `must_succeed: false` to the kickstart in the generated-cask template (mirrors the fix already pushed to the live tap `vibecare-io/homebrew-apps`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)