### PR TITLE
fix(client): update check uses github.com redirect (no API rate limit)

### DIFF
--- a/clients/macos-swift/VibeCare/VibeCare/Services/UpdateChecker.swift
+++ b/clients/macos-swift/VibeCare/VibeCare/Services/UpdateChecker.swift
@@ -4,8 +4,13 @@ import Foundation
 /// latest GitHub release tag. No auto-update, no download — just "is a newer
 /// version available?" so the About settings can tell the user to `brew upgrade`.
 enum UpdateChecker {
+    /// github.com's "latest release" endpoint. Hitting this (rather than
+    /// `api.github.com`) avoids the unauthenticated REST API's 60-req/hr rate
+    /// limit — that limit returns HTTP 403 once exhausted and caused intermittent
+    /// "couldn't check for updates". The web endpoint 302-redirects to
+    /// `.../releases/tag/<tag>`, so the tag is right in the `Location` header.
     static let latestReleaseURL =
-        URL(string: "https://api.github.com/repos/vibecare-io/vibecare/releases/latest")!
+        URL(string: "https://github.com/vibecare-io/vibecare/releases/latest")!
 
     /// A newer release exists iff the latest tag differs from the installed
     /// version. GitHub's "latest release" is authoritative (it's the newest
@@ -18,17 +23,38 @@ enum UpdateChecker {
         return l != i
     }
 
-    /// Fetches the latest release tag from GitHub. Returns nil on any failure
-    /// (offline, rate-limited, etc.) — the caller shows a soft "try again".
+    /// Extracts the tag from a `…/releases/tag/<tag>` redirect Location.
+    /// Pure + testable.
+    static func tag(fromLocation location: String) -> String? {
+        guard let range = location.range(of: "/releases/tag/") else { return nil }
+        let tag = String(location[range.upperBound...])
+            .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        return tag.isEmpty ? nil : tag
+    }
+
+    /// Fetches the latest release tag by reading the 302 redirect's `Location`
+    /// header (does NOT follow the redirect, so no extra request and no API
+    /// rate limit). Returns nil on any failure — the caller shows a soft retry.
     static func latestVersion() async -> String? {
         var req = URLRequest(url: latestReleaseURL)
         req.timeoutInterval = 10
-        req.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
-        guard let (data, resp) = try? await URLSession.shared.data(for: req),
-              let http = resp as? HTTPURLResponse, http.statusCode == 200,
-              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-              let tag = obj["tag_name"] as? String
+        let session = URLSession(configuration: .ephemeral)
+        guard let (_, resp) = try? await session.data(for: req, delegate: NoRedirectDelegate()),
+              let http = resp as? HTTPURLResponse,
+              (300..<400).contains(http.statusCode),
+              let location = http.value(forHTTPHeaderField: "Location")
         else { return nil }
-        return tag
+        return tag(fromLocation: location)
+    }
+}
+
+/// URLSession delegate that stops at the first redirect so we can read its
+/// `Location` header instead of following it.
+private final class NoRedirectDelegate: NSObject, URLSessionTaskDelegate {
+    func urlSession(_ session: URLSession, task: URLSessionTask,
+                    willPerformHTTPRedirection response: HTTPURLResponse,
+                    newRequest request: URLRequest,
+                    completionHandler: @escaping (URLRequest?) -> Void) {
+        completionHandler(nil)
     }
 }

--- a/clients/macos-swift/VibeCare/vibecareTests/UpdateCheckerTests.swift
+++ b/clients/macos-swift/VibeCare/vibecareTests/UpdateCheckerTests.swift
@@ -1,6 +1,13 @@
 import Testing
 @testable import vibecare
 
+@Test func parsesTagFromReleasesLatestRedirect() {
+    #expect(UpdateChecker.tag(fromLocation: "https://github.com/vibecare-io/vibecare/releases/tag/v0.8.10.26-2") == "v0.8.10.26-2")
+    #expect(UpdateChecker.tag(fromLocation: "https://github.com/vibecare-io/vibecare/releases/tag/v1.0.0/") == "v1.0.0")
+    #expect(UpdateChecker.tag(fromLocation: "https://github.com/vibecare-io/vibecare/releases") == nil)
+    #expect(UpdateChecker.tag(fromLocation: "") == nil)
+}
+
 @Test func updateAvailableOnlyWhenLatestTagDiffers() {
     // Same version → up to date
     #expect(UpdateChecker.isUpdateAvailable(installed: "v0.8.10.26-1", latest: "v0.8.10.26-1") == false)


### PR DESCRIPTION
## Problem
"Check for Updates" intermittently showed **"Couldn't check for updates."** Root cause is GitHub's unauthenticated REST API rate limit: `api.github.com/repos/.../releases/latest` allows ~**60 req/hr per IP** and returns **HTTP 403** once exhausted (`x-ratelimit-remaining: 0`).

## Fix
Read the latest tag from **`https://github.com/vibecare-io/vibecare/releases/latest`**, which `302`-redirects to `…/releases/tag/<tag>` — the tag is in the `Location` header. This is the regular web endpoint (no tight rate limit), one request, no redirect followed. Adds a pure `tag(fromLocation:)` parser with a unit test; `isUpdateAvailable` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)