### PR TITLE
Build backend, client and each plugin in parallel

### DIFF
--- a/.github/scripts/embed-plugins.sh
+++ b/.github/scripts/embed-plugins.sh
@@ -16,12 +16,19 @@
 # Info.plist beside a same-named executable reads as a flat bundle to
 # codesign, and AMFI then SIGKILLs the plugin the instant core spawns it).
 #
-# Usage: embed-plugins.sh <app-bundle> [plugins-src-dir]
+# Usage: embed-plugins.sh <app-bundle> [plugins-src-dir] [expected-count]
+#
+# expected-count, when given, is how many plugins the caller believes should
+# land. CI passes the number of manifests in the repo, so a plugin whose build
+# job failed — or one added without a matching row in the release workflow's
+# build matrix — fails the release instead of shipping an app quietly missing
+# a feature. That silent-omission bug is the whole reason this script exists.
 
 set -euo pipefail
 
 APP_BUNDLE="${1:?App bundle path required}"
 SRC="${2:-plugins}"
+EXPECTED="${3:-}"
 DEST="${APP_BUNDLE}/Contents/Resources/plugins"
 
 if [ ! -d "$APP_BUNDLE" ]; then
@@ -76,6 +83,13 @@ done
 # build instead.
 if [ "$embedded" -eq 0 ]; then
     echo "Error: no plugins embedded from $SRC" >&2
+    exit 1
+fi
+
+if [ -n "$EXPECTED" ] && [ "$embedded" -ne "$EXPECTED" ]; then
+    echo "Error: embedded $embedded plugin(s), expected $EXPECTED" >&2
+    echo "       A plugin's build job failed, or a plugin was added without a" >&2
+    echo "       matching row in the release workflow's build-plugin matrix." >&2
     exit 1
 fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,10 +67,125 @@ jobs:
           path: backend-binary.tar
           retention-days: 1
 
+  # Just the client binary. Bundle creation, embedding and signing all moved
+  # to assemble-app: while this job also assembled the bundle it had to wait
+  # for the backend, which serialised three builds that share nothing but
+  # their output directory.
   build-macos-client:
     name: Build macOS Swift Client
     runs-on: macos-latest
-    needs: build-backend
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Swift client environment
+        uses: ./.github/actions/setup-swift-client
+
+      - name: Build Swift client
+        run: |
+          cd clients/macos-swift/VibeCare
+          swift build -c release --product VibeCare --jobs $(sysctl -n hw.ncpu)
+          cp .build/release/VibeCare ../../../vibecare-client
+          chmod +x ../../../vibecare-client
+
+      - name: Tar client binary (preserve permissions)
+        run: tar -cvf client-binary.tar vibecare-client
+
+      - name: Upload client binary artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: client-binary
+          path: client-binary.tar
+          retention-days: 1
+
+  # One job per plugin, in parallel. Plugins are where every feature actually
+  # lives, so a release without them installs cleanly and does nothing.
+  #
+  # The stack is declared per plugin rather than inferred, because the two
+  # differ in what they need and neither need is guessable from the directory:
+  #
+  #   * go    — needs protoc and a proto-gen run, not merely a Go toolchain.
+  #     backend/pkg/proto/ is generated and NOT committed, and plugins/todo
+  #     has `replace ... => ../../backend`, so its build reaches straight into
+  #     stubs that do not exist until setup-go-backend has run.
+  #   * swift — needs nothing but the runner's Xcode toolchain. These plugins'
+  #     stubs ARE committed (sdk/swift/VCPluginSDK/Sources/VCKStubs), so no
+  #     generation step applies.
+  #
+  # Adding a plugin means adding a row here. Forgetting to is caught at
+  # assembly, which fails when fewer plugins are embedded than the repo has
+  # manifests — silently shipping without one is the bug this all fixes.
+  build-plugin:
+    name: Build Plugin (${{ matrix.id }})
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { id: todo, stack: go }
+          - { id: vision, stack: swift }
+          - { id: vibecheck, stack: swift }
+          - { id: postures, stack: swift }
+          - { id: blink-jump, stack: swift }
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Go backend environment
+        if: matrix.stack == 'go'
+        uses: ./.github/actions/setup-go-backend
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      # Per-plugin SwiftPM cache. Deliberately not setup-swift-client, whose
+      # cache is keyed to the client's Package.resolved and would thrash
+      # against five unrelated dependency graphs.
+      - name: Cache SwiftPM build
+        if: matrix.stack == 'swift'
+        uses: actions/cache@v4
+        with:
+          path: |
+            plugins/${{ matrix.id }}/.build
+            ~/Library/Caches/org.swift.swiftpm
+          key: ${{ runner.os }}-plugin-${{ matrix.id }}-${{ hashFiles(format('plugins/{0}/Package.resolved', matrix.id)) }}
+          restore-keys: |
+            ${{ runner.os }}-plugin-${{ matrix.id }}-
+
+      - name: Install just
+        uses: extractions/setup-just@v3
+
+      # Via just, not inline: the Justfile is the single definition of every
+      # plugin's build, and some have subtleties that fail SILENTLY when
+      # guessed — vision's -sectcreate Info.plist and the signature that seals
+      # it, and the staged dist/ layout that stops codesign resolving a plugin
+      # directory as a flat bundle.
+      - name: Build plugin
+        run: just build-${{ matrix.id }}-plugin
+
+      # Ship the plugin directory minus its build tree. assemble-app extracts
+      # these and hands the result to embed-plugins.sh, so the per-plugin
+      # layout rules (dist/ as dist/, resource bundle beside the binary) stay
+      # defined in exactly one place rather than being re-encoded here.
+      - name: Tar plugin (preserve permissions)
+        run: tar -cvf plugin-${{ matrix.id }}.tar --exclude='.build' -C plugins ${{ matrix.id }}
+
+      - name: Upload plugin artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: plugin-${{ matrix.id }}
+          path: plugin-${{ matrix.id }}.tar
+          retention-days: 1
+
+  # Everything signed happens here, in one job with one certificate import,
+  # so the inside-out order is visible in a single file: plugins first, then
+  # the bundle. (The server arrives already signed from build-backend; the
+  # bundle's signature seals it rather than re-signing it.)
+  assemble-app:
+    name: Assemble and Sign App Bundle
+    runs-on: macos-latest
+    needs: [build-backend, build-macos-client, build-plugin]
 
     steps:
       - name: Checkout code
@@ -85,9 +200,6 @@ jobs:
           event-name: ${{ github.event_name }}
           manual-version: ${{ github.event.inputs.version }}
 
-      - name: Setup Swift client environment
-        uses: ./.github/actions/setup-swift-client
-
       - name: Import certificates
         id: certs
         uses: ./.github/actions/import-certificates
@@ -95,26 +207,33 @@ jobs:
           certificate-app-base64: ${{ secrets.APPLE_CERTIFICATE_APP_BASE64 }}
           certificate-password: ${{ secrets.APPLE_CERT_PASSWORD }}
 
-      - name: Build Swift client
-        run: |
-          cd clients/macos-swift/VibeCare
-          swift build -c release --product VibeCare --jobs $(sysctl -n hw.ncpu)
-          cp .build/release/VibeCare ../../../vibecare-client
-          chmod +x ../../../vibecare-client
+      - name: Download client binary
+        uses: actions/download-artifact@v4
+        with:
+          name: client-binary
+          path: .
+
+      - name: Download backend binary
+        uses: actions/download-artifact@v4
+        with:
+          name: backend-binary
+          path: .
+
+      - name: Download plugin artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: plugin-*
+          merge-multiple: true
+          path: plugin-tars
 
       - name: Create app bundle
         run: |
+          tar -xvf client-binary.tar
           ./.github/scripts/create-app-bundle.sh \
             "VibeCare" \
             "vibecare-client" \
             "${{ steps.version.outputs.version }}" \
             "io.vibecare.app"
-
-      - name: Download backend artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: backend-binary
-          path: .
 
       - name: Embed server + LaunchAgent into app bundle
         run: |
@@ -125,27 +244,29 @@ jobs:
           cp .github/scripts/io.vibecare.server.plist \
              VibeCare.app/Contents/Library/LaunchAgents/io.vibecare.server.plist
 
-      # Plugins are where every feature actually lives, so a release without
-      # them installs cleanly and does nothing. They ship inside the bundle
-      # beside the server, which finds them from its own path — no plugins
-      # directory has to be named in the LaunchAgent plist. See
-      # resolvePluginsDirs in backend/cmd/server/main.go.
-      - name: Install just
-        uses: extractions/setup-just@v3
+      # Into a clean directory, NOT over the checked-out plugins/. Extracting
+      # over the source tree would leave a failed plugin's manifest in place
+      # with no binary beside it, which is exactly the state the expected-count
+      # check below exists to catch.
+      - name: Unpack built plugins
+        run: |
+          mkdir -p built-plugins
+          for t in plugin-tars/*.tar; do
+            echo "unpacking $t"
+            tar -xf "$t" -C built-plugins
+          done
+          ls -la built-plugins
 
-      # Via just, not inline: the Justfile is the single definition of the
-      # per-plugin build, and two of them have subtleties that fail silently
-      # when guessed (vision's -sectcreate Info.plist and the signature that
-      # seals it, and the staged dist/ layout that keeps codesign from
-      # resolving a plugin directory as a flat bundle).
-      - name: Build plugins
-        run: just build-plugins
-
+      # Third argument is how many plugins the repo declares. Fewer embedded
+      # than that fails the release rather than shipping an app quietly
+      # missing a feature.
       - name: Embed plugins into app bundle
-        run: ./.github/scripts/embed-plugins.sh VibeCare.app
+        run: |
+          expected=$(ls -d plugins/*/manifest.yaml 2>/dev/null | wc -l | tr -d ' ')
+          ./.github/scripts/embed-plugins.sh VibeCare.app built-plugins "$expected"
 
-      # Inside-out: every plugin executable first, the app bundle last, so
-      # the bundle's signature seals children that are already valid.
+      # Inside-out: every plugin executable first, the app bundle last, so the
+      # bundle's signature seals children that are already valid.
       - name: Sign embedded plugins
         uses: ./.github/actions/sign-plugins
         with:
@@ -172,7 +293,7 @@ jobs:
   create-release:
     name: Create Release Package
     runs-on: macos-latest
-    needs: [build-backend, build-macos-client]
+    needs: [assemble-app]
     permissions:
       contents: write
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,8 @@ VibeCare is a wellness and routine management mono-repo:
 
 ```bash
 just setup              # First-time: install deps, proto-gen, migrate
+just build              # Build everything: backend, CLI, plugins, Swift client
+just build-backend      # Build only the backend server -> bin/vibecare-server
 just run                # Start backend (gRPC :50051 + HTTP :8080)
 just test               # Backend tests
 just proto-gen          # Regenerate protobuf for backend + Swift

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -108,10 +108,12 @@ cd vibecare
 # Setup development environment
 just setup
 
-# Build backend
+# Build everything (backend, CLI, plugins, Swift client)
 just build
 
-# Build Swift client
+# Or build one piece at a time
+just build-backend
+just build-plugins
 just swift-build
 
 # Run backend

--- a/Justfile
+++ b/Justfile
@@ -90,9 +90,24 @@ new-migration name:
     @echo "{{GREEN}}Creating new migration: {{name}}{{NC}}"
     cd {{backend_dir}} && goose -dir internal/storage/migrations create {{name}} sql
 
+# Debug builds — `install-binaries` is the release path.
+#
+# Order is deliberate. The backend is the fastest thing here and the most
+# likely to be broken by a proto change, so it fails first; the two Swift
+# trees (plugins, then the client) are the slow tail and go last.
+#
+# Not included: proto-gen (generated stubs are committed — run `just
+# proto-gen` yourself after editing a .proto) and install-plugins (this
+# builds into the repo's plugins/, which is what `just run` scans).
+#
+# Build everything: backend, CLI, every plugin, macOS client
+[group('📦 Build & Run')]
+build: build-backend cli-build build-plugins swift-build
+    @echo "{{GREEN}}✓ Everything built: backend, CLI, plugins, macOS client{{NC}}"
+
 # Build the backend server
 [group('📦 Build & Run')]
-build:
+build-backend:
     @echo "{{GREEN}}Building VibeCare server...{{NC}}"
     cd {{backend_dir}} && go build -o ../bin/vibecare-server cmd/server/main.go
     @echo "{{GREEN}}✓ Server built: bin/vibecare-server{{NC}}"
@@ -286,6 +301,8 @@ build-mcp-standalone:
 # Build the kernel's todo reference plugin into its own directory — core
 # discovers plugins by scanning plugins/<id>/manifest.yaml, so the binary
 # lives alongside the manifest rather than under ~/.vibecare.
+#
+# Build the todo reference plugin (Go)
 [group('🧩 Plugins')]
 build-todo-plugin:
     @echo "{{GREEN}}Building todo plugin...{{NC}}"
@@ -304,6 +321,8 @@ build-todo-plugin:
 # to install): the TCC grant is keyed to the spawning process
 # (vibecare-server), not to this binary, so an ad-hoc signature is fine
 # and the grant survives rebuilds.
+#
+# Build the vibecheck plugin (Swift)
 [group('🧩 Plugins')]
 build-vibecheck-plugin:
     @echo "{{GREEN}}Building vibecheck plugin...{{NC}}"
@@ -505,6 +524,8 @@ build-plugins-dev:
 # vision goes first: it is the camera provider every other Swift plugin here
 # consumes, so a failure in it is the one worth seeing before the rest of the
 # output scrolls past.
+#
+# Build every plugin binary into its own directory
 [group('🧩 Plugins')]
 build-plugins: build-todo-plugin build-vision-plugin build-vibecheck-plugin build-postures-plugin build-blink-jump-plugin
     @echo "{{GREEN}}✓ All plugins built{{NC}}"
@@ -1195,10 +1216,12 @@ macos-build:
 xcode:
     open clients/macos-swift/VibeCare.xcodeproj
 
-# Full build: backend and macOS client
+# Kept as an alias: `build` used to be backend-only and this was the
+# everything recipe. `build` is now the everything recipe.
+#
+# Alias for `just build`
 [group('📦 Build & Run')]
-build-all: build swift-build
-    @echo "{{GREEN}}✓ All components built{{NC}}"
+build-all: build
 
 # Trigger GitHub release workflow
 [group('🚀 Release')]

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -41,9 +41,8 @@ git pull origin main
 just test
 just swift-test
 
-# Build and test locally
+# Build and test locally (backend, CLI, plugins, Swift client)
 just build
-just swift-build
 
 # Optional: Test PKG creation locally
 ./scripts/build-release.sh


### PR DESCRIPTION
Fixes the `v0.8.16.26` release failure and restructures the release workflow so the three build stages run concurrently.

## Why it failed

`just build-plugins` ran inside `build-macos-client`, which sets up Swift and nothing else — hence `go: command not found` on the todo plugin.

Adding a Go toolchain there would have failed one step later: **`backend/pkg/proto/` is generated, not committed** (0 files tracked), and `plugins/todo/go.mod` has `replace github.com/vibecare-io/vibecare/backend => ../../backend`. The todo plugin reaches straight into stubs that don't exist until `setup-go-backend` has run protoc.

## What changed

`build-macos-client` was doing two unrelated jobs — building the Swift client *and* assembling and signing the bundle. The assembly half is why it needed the backend, why it serialised three builds that share nothing but an output directory, and why the plugin build ended up in a job with the wrong toolchain.

```
before:  build-backend ──→ build-macos-client (client + 5 plugins + assemble + sign) ──→ create-release

after:   build-backend    ─┐
         build-macos-client ┤
         build-plugin (×5)  ┼──→ assemble-app ──→ create-release ──→ update-homebrew-tap
```

**Per-plugin matrix with a declared stack.** The two stacks differ in ways nothing about the directory reveals — `go` needs protoc and a generation run, `swift` needs only the runner's Xcode toolchain because those stubs *are* committed (`VCKStubs/*.pb.swift`). A new stack later is one more `if`, not a new workflow file. The four Swift plugin builds were sequential inside one job and are now concurrent, each with its own SwiftPM cache rather than the client's.

**Artifact path.** Each plugin ships its directory minus `.build`; `assemble-app` unpacks into a clean directory and hands that to `embed-plugins.sh`, so the layout rules stay defined once. Unpacking into a clean directory rather than over the checkout matters — extracting over the source tree would leave a failed plugin's manifest in place with no binary beside it.

**Fails loudly on a missing plugin.** `embed-plugins.sh` now takes an expected count and CI passes the number of manifests in the repo. A plugin whose job failed, or one added without a matrix row, fails the release instead of shipping an app quietly missing a feature.

**Signing unchanged and still in one place** — one certificate import, plugins first, bundle last.

## Verification

Simulated the whole artifact path locally: tar each plugin the way the matrix job does, extract the way `assemble-app` does, embed, ad-hoc sign through the same find-Mach-O logic the `sign-plugins` action uses, then run the server with no `--plugins-dir`.

```
discovered plugins  {"bundled_dir": ".../Resources/plugins", "count": 5}
plugin state {"plugin": "todo",       "state": "up"}
plugin state {"plugin": "postures",   "state": "up"}
plugin state {"plugin": "blink-jump", "state": "up"}
plugin state {"plugin": "vibecheck",  "state": "up"}
plugin state {"plugin": "vision",     "state": "up"}
```

Exec bits survive the tar round-trip. The expected-count check was tested both ways — 5/5 passes, 4/5 fails the build with an actionable message.

## What's still unexercised

The runner-side pieces can't be verified locally: `extractions/setup-just@v3`, `setup-go-backend` inside a plugin job, and four concurrent Swift builds on macOS runners. Those are what the next tag will actually test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)