### PR TITLE
Fix entitlements XML that broke the signing step

### DIFF
--- a/.github/actions/sign-plugins/action.yml
+++ b/.github/actions/sign-plugins/action.yml
@@ -30,6 +30,27 @@ runs:
           exit 1
         fi
 
+        ENTDIR=".github/scripts/plugin-entitlements"
+
+        # Validate every entitlements file with a STRICT parser first.
+        #
+        # codesign hands these to AMFIUnserializeXML, which is far less
+        # forgiving than the CoreFoundation parser behind `plutil -lint` — and
+        # when it refuses, it says only "syntax error near line N". The
+        # v0.8.16.26 release died that way: a `--` inside an XML comment, which
+        # the spec forbids and plutil happily accepted. xmllint agrees with
+        # AMFI and says which rule was broken, so check here and fail readably
+        # rather than mid-signing.
+        if [ -d "$ENTDIR" ]; then
+          for f in "$ENTDIR"/*.entitlements; do
+            [ -f "$f" ] || continue
+            if ! xmllint --noout "$f"; then
+              echo "Error: $f is not valid XML; codesign will reject it" >&2
+              exit 1
+            fi
+          done
+        fi
+
         # Signing must go inside-out: each nested executable first, the app
         # bundle last. The outer signature then seals children that are
         # already valid. Done the other way round, re-signing the app
@@ -54,10 +75,11 @@ runs:
           # com.apple.security.device.camera because the hardened runtime
           # denies capture without it — and denies it silently, which reads
           # as "the camera plugin is broken" rather than as a signing problem.
-          ents=".github/scripts/plugin-entitlements/${id}.entitlements"
+          ents="$ENTDIR/${id}.entitlements"
           entflags=()
           if [ -f "$ents" ]; then
             entflags=(--entitlements "$ents")
+            used_ents="${used_ents-} ${id}"
             echo "  using entitlements $ents"
           fi
 
@@ -75,6 +97,21 @@ runs:
             "$bin"
 
           codesign --verify --strict --verbose=2 "$bin"
+
+          # Read the entitlements back off the binary. A signature that
+          # succeeded without them is the dangerous case: vision would ship
+          # with the hardened runtime and no camera entitlement, and the
+          # runtime denies capture SILENTLY — surfacing as a dead camera on a
+          # user's machine rather than as a red build here.
+          if [ -f "$ents" ]; then
+            if ! codesign -d --entitlements - --xml "$bin" 2>/dev/null \
+                 | grep -q "com.apple.security"; then
+              echo "Error: $id was signed but carries no entitlements" >&2
+              exit 1
+            fi
+            echo "  ✓ entitlements verified on $id"
+          fi
+
           signed=$((signed + 1))
         done < <(
           find "$PLUGINS" -type f -perm -u+x -exec sh -c \
@@ -85,6 +122,24 @@ runs:
         if [ "$signed" -eq 0 ]; then
           echo "Error: found no plugin executables to sign under $PLUGINS" >&2
           exit 1
+        fi
+
+        # Every entitlements file must have matched a plugin. Because the
+        # mapping is by filename, a typo or a plugin rename would otherwise
+        # skip the entitlements in complete silence — the build stays green
+        # and the camera dies in production.
+        if [ -d "$ENTDIR" ]; then
+          for f in "$ENTDIR"/*.entitlements; do
+            [ -f "$f" ] || continue
+            want="$(basename "$f" .entitlements)"
+            case " ${used_ents-} " in
+              *" $want "*) ;;
+              *)
+                echo "Error: $f matched no signed plugin" >&2
+                echo "       Expected a plugin with id '$want'. Renamed or misspelled?" >&2
+                exit 1 ;;
+            esac
+          done
         fi
 
         echo "✓ Signed $signed plugin executable(s)"

--- a/.github/scripts/plugin-entitlements/README.md
+++ b/.github/scripts/plugin-entitlements/README.md
@@ -1,0 +1,52 @@
+# Per-plugin entitlements
+
+One `<id>.entitlements` file per plugin that needs entitlements of its own.
+`.github/actions/sign-plugins` picks them up **by filename alone** — a plugin
+named `foo` gets `foo.entitlements` if it exists, and no entitlements if it
+does not. Adding one for a new plugin is a file, not a code change.
+
+## Keep these files bare
+
+No comments. No prose. Just the dict.
+
+Entitlements are parsed by AMFI's `AMFIUnserializeXML`, a restricted XML
+parser, not by the forgiving one behind `plutil`. Anything it dislikes fails
+the signing step with a bare line number and nothing else:
+
+```
+Failed to parse entitlements: AMFIUnserializeXML: syntax error near line 7
+```
+
+That is exactly how the `v0.8.16.26` release died. The file carried an
+explanatory comment, and the comment contained the string `--` (it mentioned
+codesign's `--options runtime` flag). XML forbids a double hyphen inside a
+comment, so the file was genuinely malformed — but `plutil -lint` reported
+`OK`, because CoreFoundation tolerates what AMFI rejects. Use
+`xmllint --noout` if you want a parser that agrees with AMFI; `sign-plugins`
+now runs it on every file here before signing, so this fails with a readable
+message instead of a line number.
+
+Rationale for a given entitlement belongs here, in Markdown, where `--` is
+just a hyphen.
+
+## Why vision needs `com.apple.security.device.camera`
+
+`plugins/vision` is the one process that opens the camera. Release builds
+sign plugins with the hardened runtime, which denies camera access to any
+process that does not hold this entitlement — and denies it **silently**. The
+symptom is "vision publishes no frames", which reads as a broken plugin
+rather than as a signing problem, so nothing points you back here.
+
+This is separate from the TCC grant, and does not replace it. That grant is
+keyed to the *spawning* process (`vibecare-server`), not to this binary, so
+nothing here re-prompts the user. The entitlement only stops the hardened
+runtime from refusing the capture the grant already allows.
+
+## Guards
+
+`sign-plugins` fails the build if a file in this directory matches no plugin
+it signed. A typo or a plugin rename would otherwise mean the entitlements
+are silently skipped — vision would ship with the hardened runtime and no
+camera entitlement, and the failure would surface as a dead camera on a
+user's machine rather than as a red CI run. It also reads the entitlements
+back off each signed binary to confirm they actually landed.

--- a/.github/scripts/plugin-entitlements/vision.entitlements
+++ b/.github/scripts/plugin-entitlements/vision.entitlements
@@ -1,21 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<!--
-  Entitlements for plugins/vision, the one process that opens the camera.
-
-  Required because the release build signs plugins with the hardened runtime
-  (--options runtime), which denies camera access to a process that does not
-  hold com.apple.security.device.camera. It denies it silently, so the
-  symptom is "vision publishes no frames" rather than anything naming a
-  signature — which is why this file exists rather than the entitlement being
-  left to the app bundle's.
-
-  Separate from the TCC grant. That grant is keyed to the SPAWNING process
-  (vibecare-server), not to this binary, so nothing here re-prompts the user;
-  this only stops the runtime from refusing the capture the grant allows.
-
-  Picked up by .github/actions/sign-plugins purely by filename: <id>.entitlements.
--->
 <plist version="1.0">
 <dict>
 	<key>com.apple.security.device.camera</key>


### PR DESCRIPTION
`v0.8.16.26` died at **Sign embedded plugins**:

```
Failed to parse entitlements: AMFIUnserializeXML: syntax error near line 7
```

Everything before it worked — the parallel builds, the plugin matrix, and embed all succeeded. This is the last mile.

## Root cause

Line 7 was inside the entitlements file's explanatory comment, and that comment mentioned codesign's `--options runtime` flag:

```xml
  (--options runtime), which denies camera access to a process that does not
```

**XML forbids the string `--` inside a comment.** The file was genuinely malformed — my comment prose broke it.

It slipped through because the obvious check passes:

```
$ plutil -lint vision.entitlements
vision.entitlements: OK           ← CoreFoundation tolerates it

$ xmllint --noout vision.entitlements
parser error : Double hyphen within comment    ← AMFI agrees with this one
```

`codesign` hands entitlements to AMFI's restricted `AMFIUnserializeXML`, not to the forgiving CoreFoundation parser. Confirmed by isolating it — signing fails with the `--`, succeeds with only that string changed and nothing else.

## Fix

Entitlements files are now **bare**: no comments, just the dict. The rationale moved to a `README.md` beside them, where `--` is only a hyphen. Explaining a codesign flag inside a file parsed by a restricted XML parser was never worth the risk.

## Guards

The loud failure stopped a release. The silent variants are worse, so all three are now checked:

1. **`xmllint --noout` on every entitlements file before signing** — fails with the broken rule and a caret at the offending text, instead of AMFI's bare line number.
2. **Read entitlements back off each signed binary.** A signature that succeeds while dropping them is the dangerous case: vision would ship with the hardened runtime and no camera entitlement, and the runtime denies capture *silently* — surfacing as a dead camera on a user's machine rather than a red build.
3. **Fail if an entitlements file matches no signed plugin.** The mapping is by filename, so a typo or a plugin rename would otherwise skip entitlements in complete silence and leave the build green.

## Verification

Ran the action's own script body against a real assembled bundle:

```
  using entitlements .github/scripts/plugin-entitlements/vision.entitlements
  ✓ entitlements verified on vision
✓ Signed 5 plugin executable(s)
```

Both new guards tested by breaking things deliberately:

```
# reintroduce the exact release-breaking `--`
 uses --options runtime
      ^
Error: .../vision.entitlements is not valid XML; codesign will reject it

# misspell the filename
Error: .../visoin.entitlements matched no signed plugin
       Expected a plugin with id 'visoin'. Renamed or misspelled?
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)