### PR TITLE
Fix bash 3.2 empty-array expansion in sign-plugins

### DIFF
--- a/.github/actions/sign-plugins/action.yml
+++ b/.github/actions/sign-plugins/action.yml
@@ -90,10 +90,18 @@ runs:
           # just build-vision-plugin — codesign resolves the directory as a
           # flat bundle and AMFI SIGKILLs the process at spawn while
           # `codesign --verify` still calls the file valid.
+          # ${entflags[@]+"${entflags[@]}"}, NOT "${entflags[@]}". macOS ships
+          # bash 3.2, and that is what `shell: bash` resolves to on a runner.
+          # Before 4.4, expanding an EMPTY array under `set -u` counts as an
+          # unbound variable and aborts the script. Every plugin without an
+          # entitlements file has an empty entflags, so this killed signing at
+          # the first one of those, while vision — the only plugin WITH a file
+          # — signed cleanly just before it. The `+` form expands to nothing
+          # when unset and works on both 3.2 and 5.x.
           /usr/bin/codesign --force --sign "$IDENTITY" \
             --options runtime \
             --timestamp \
-            "${entflags[@]}" \
+            ${entflags[@]+"${entflags[@]}"} \
             "$bin"
 
           codesign --verify --strict --verbose=2 "$bin"


### PR DESCRIPTION
Signing died on the plugin right after vision:

```
Signing plugin executable: .../plugins/vision/dist/vision (plugin: vision)
  ✓ entitlements verified on vision
Signing plugin executable: .../plugins/vibecheck/dist/vibecheck (plugin: vibecheck)
.../934c482b-....sh: line 75: entflags[@]: unbound variable
```

## Root cause

**macOS ships bash 3.2, and that's what `shell: bash` resolves to on a runner.** Before 4.4, expanding an *empty* array under `set -u` counts as an unbound variable and aborts the script.

Only plugins **with** an entitlements file get a non-empty `entflags`. That's exactly the shape of the log: `vision` (has a file) signed cleanly, `vibecheck` (no file) killed the step. Four of the five plugins would have hit it.

```bash
$ /bin/bash -c 'set -euo pipefail; a=(); printf "%s\n" "${a[@]}"'
/bin/bash: a[@]: unbound variable          # 3.2.57

$ bash -c 'set -euo pipefail; a=(); printf "%s\n" "${a[@]}"'
                                            # 5.3 — fine
```

## Fix

`${entflags[@]+"${entflags[@]}"}` instead of `"${entflags[@]}"`. The `+` form expands to nothing at all when the array is empty, and works on 3.2 and 5.x alike.

## Why this got through

I verified it under the wrong shell. The local check ran with whatever `bash` came first on `PATH` — Homebrew's 5.3 — where empty-array expansion is perfectly legal. The runner used `/bin/bash` 3.2.

Verification now runs the action's script body under `/bin/bash` explicitly:

```
### running under /bin/bash 3.2.57
  using entitlements .github/scripts/plugin-entitlements/vision.entitlements
  ✓ entitlements verified on vision
Signing plugin executable: .../vibecheck/dist/vibecheck (plugin: vibecheck)   ← past the failure point
✓ Signed 5 plugin executable(s)
```

Both guards from the previous PR were re-tested under 3.2 and still fire correctly (orphan entitlements file, malformed XML), and `embed-plugins.sh` was re-checked the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)