### PR TITLE
Give the cask an uninstall stanza so nothing survives removal

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -439,10 +439,36 @@ jobs:
               # agent isn't registered yet (the app registers it via SMAppService
               # on first launch), so this must NOT abort the install.
               system_command "/bin/launchctl",
-                             args: ["kickstart", "-k", "gui/#{Process.uid}/io.vibecare.server"],
-                             sudo: false,
+                             args:         ["kickstart", "-k", "gui/#{Process.uid}/io.vibecare.server"],
+                             sudo:         false,
                              must_succeed: false
             end
+
+            # Without this, `brew uninstall` removes VibeCare.app and leaves
+            # everything it started still running. Measured on 0.8.16.26: the
+            # backend kept serving HTTP 200 on :8080 with all five plugins
+            # alive, executing from a bundle that no longer existed — lsof
+            # showed the binary still mapped from the deleted path — and the
+            # LaunchAgent stayed registered, so at the next login launchd
+            # would go on trying to spawn a program that is gone. One of the
+            # survivors is `vision`, which holds the camera.
+            #
+            # Homebrew runs the uninstall keys in a fixed order, launchctl
+            # before quit, which is the order wanted here: bootout the agent
+            # so it cannot respawn the backend, then quit the app that would
+            # re-register it. Placement is not free either — `brew style`
+            # requires uninstall to sit between postflight and zap.
+            uninstall launchctl: "io.vibecare.server",
+                      quit:      "io.vibecare.app"
+
+            # Alphabetised, and zap kept directly after uninstall, because
+            # `brew style` flags both otherwise.
+            zap trash: [
+              "~/.vibecare",
+              "~/Library/Application Support/VibeCare",
+              "~/Library/Caches/io.vibecare.App.vibecare",
+              "~/Library/Preferences/io.vibecare.App.vibecare.plist",
+            ]
 
             caveats <<~EOS
               If VibeCare was previously installed with the .pkg installer, remove that
@@ -455,13 +481,6 @@ jobs:
 
               then re-run: brew install --cask vibecare
             EOS
-
-            zap trash: [
-              "~/Library/Application Support/VibeCare",
-              "~/.vibecare",
-              "~/Library/Preferences/io.vibecare.App.vibecare.plist",
-              "~/Library/Caches/io.vibecare.App.vibecare",
-            ]
           end
           CASK
 


### PR DESCRIPTION
`brew uninstall --cask vibecare` removes `VibeCare.app` and leaves everything it started **still running**.

## Measured on 0.8.16.26

```
### AFTER brew uninstall
app:            removed ✓
backend proc:   11400  ← still running
plugin procs:   4      ← still running
port 50051:     11400  ← still bound
launchd agent:  state = running
```

It kept serving:

```
$ curl http://localhost:8080/version
{"version":"v0.8.16.26"}
$ lsof -p 11400 | grep VibeCare.app
txt REG ... /Applications/VibeCare.app/Contents/Resources/vibecare-server
$ ls -d /Applications/VibeCare.app
No such file or directory
```

A backend and five plugins running out of a deleted bundle, indefinitely. The LaunchAgent registration survives too, so at next login launchd keeps trying to spawn a program that's gone. One of the survivors is `vision`, which holds the camera — a process the user believes they just uninstalled.

The cask had only `postflight` and `zap`. Nothing ever stopped what the app started, because nothing was asked to.

## Fix

```ruby
uninstall launchctl: "io.vibecare.server",
          quit:      "io.vibecare.app"
```

Homebrew runs the uninstall keys in a fixed order — `launchctl` before `quit` — which is the order wanted here: bootout the agent so it can't respawn the backend, then quit the app that would re-register it.

Placement isn't free: `brew style` requires `uninstall` between `postflight` and `zap`, so `caveats` moves to the end. That surfaced 5 pre-existing offences in the generated cask (zap out of order, zap array unalphabetised, postflight argument alignment), all fixed here.

## Verification

Extracted the cask this workflow generates, installed it into the local tap, ran the real commands:

```
$ brew style --cask vibecare-io/apps/vibecare
1 file inspected, no offenses detected          (was: 5 offenses)

$ brew uninstall --cask --verbose vibecare
==> Uninstalling Cask vibecare
==> Removing launchctl service io.vibecare.server     ← stanza executes
==> Removing App '/Applications/VibeCare.app'          ← and before removal
```

The local tap was restored to upstream afterwards.

**Partial:** `quit:` didn't fire in that run because the app wasn't open, and the end-to-end "backend actually reaped" check needs the bundled backend running, which a local `just run` dev server was blocking on `:50051`. The stanza is confirmed wired and executing; the reap itself is confirmed by Homebrew's documented behaviour rather than observed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)