### PR TITLE
Notifications: rich renderer, break countdown, and global appearance settings

### DIFF
--- a/clients/macos-swift/VibeCare/CLAUDE.md
+++ b/clients/macos-swift/VibeCare/CLAUDE.md
@@ -42,7 +42,119 @@ let profiles = try await GRPCClientManager.shared.withProfileServiceClient { cli
 - `EventService` streams real-time events from backend via SSE
 
 ### Notifications
-Custom [VibeNotify](https://github.com/vibecare-io/vibe-notify-macos) library — bypasses native `UNUserNotificationCenter` for custom styling, positioning, and interactive actions.
+Custom [VibeNotify](https://github.com/vibecare-io/vibe-notify-macos) library — bypasses native `UNUserNotificationCenter` for custom styling, positioning, and interactive actions. See [Notifications](#notifications) below.
+
+## Notifications
+
+Two paths reach the screen, and both render through VibeNotify's **rich
+renderer** (`RichNotification` / `RichNotificationView`) — the only one that
+draws an illustration, buttons and a countdown together:
+
+| Path | Entry point | Mode |
+|---|---|---|
+| Schedule actions | `VibeNotifyConfig.showScheduleNotification` → `showNotification` (`Services/VibeNotifyConfiguration.swift`) | `.interrupt` when blur is on **or** a task timer is set; `.ambient` otherwise |
+| Plugin alerts | `PluginAlertPresenter.show` (`Views/Plugins/PluginAlertOverlay.swift`) | always `.ambient` |
+
+Plugin alerts are `.ambient` even when the appearance asked for blur: a plugin
+authors its alert's geometry, and `.interrupt` deliberately ignores position and
+size in order to own the whole screen. `PluginAlertPresentation.blurIntensity`
+consequently reaches no window.
+
+A plugin alert falls back to the **standard banner** (`showWarning`/`showInfo`)
+in two cases, both in `PluginShellService`: no appearance blob at all, or an
+appearance that asked for an illustration whose fetch failed. Losing the picture
+is cosmetic; losing the buttons — "Turn off" on a camera the user wants stopped
+— would not be, and the banner still draws them.
+
+The generic helpers (`showSuccess`/`showError`/`showWarning`/`showInfo`/`showToast`)
+still go through the old builder path and the standard renderer. They are
+banners, not break alerts.
+
+### Global settings
+
+The durable copy lives in `Profile.preferences` — already a
+`map<string, string>` on the wire, so this needed no proto change and no
+migration, and it syncs across devices. `UserDefaults` is written as a **mirror,
+not a second source of truth**: notifications can fire before the profile has
+loaded, and reading them must not be async or main-actor-bound. `hydrate(from:)`
+overwrites the mirror whenever a profile arrives, so the server wins.
+
+Keys, all under `notify.` (`Services/GlobalNotificationSettings.swift`):
+
+`notify.position`, `notify.width`, `notify.height`, `notify.blur_enabled`,
+`notify.blur_intensity`, `notify.screen_dim`, `notify.backdrop_style`,
+`notify.auto_dismiss_after`, `notify.moveable`, `notify.break_unit_label`,
+`notify.break_completion_label`.
+
+`notify.backdrop_style` is **global-only** — no per-action override, and absent
+from `appearanceParameterKeys`. A break backdrop is a property of this machine's
+idea of restful, not of the routine that fired the alert.
+
+### Resolution order
+
+1. `GlobalNotificationSettings` — the defaults, set once in Settings.
+2. The action's own `parameters` — any key present wins **for that key alone**,
+   never for the whole set.
+
+So an action that specifies nothing gets the global look, and an action that
+specifies `position: topRight` keeps `topRight` and inherits everything else.
+`GlobalNotificationSettings.resolving(actionParameters:)` is the single place
+that rule is expressed. There is no separate "is overridden" flag: the presence
+of the keys *is* the persisted override state, which is why an action authored
+by the CLI or MCP reads correctly without this app having written it.
+
+### Action `parameters` keys
+
+A schedule action's `parameters` map is how a notification is configured. Note
+the appearance keys are **unprefixed** here and spelled differently from their
+global counterparts (`screen_blur_enabled`, not `notify.blur_enabled`).
+
+**Content** — no global counterpart, so absent simply means absent:
+
+| Key | Value |
+|---|---|
+| `title` | Alert title |
+| `body` | Alert message |
+| `svg_path` | Full URL for a bundled icon, or a file path for a custom one |
+| `svg_width`, `svg_height` | Illustration size in points |
+
+**Break countdown** — the knobs that turn a notification into a timed break:
+
+| Key | Value | Fallback |
+|---|---|---|
+| `task_timer_seconds` | Duration of the countdown ring, in seconds. **Absent or unparseable means no ring at all** | none — action-only |
+| `task_timer_unit_label` | The word under the number | `notify.break_unit_label` ("seconds") |
+| `task_timer_completion_label` | What the ring's centre says at zero | `notify.break_completion_label` ("Break complete") |
+
+**Appearance** — global unless the action says otherwise:
+
+| Key | Values |
+|---|---|
+| `position` | `center`, `topLeft`, `topRight`, `bottomLeft`, `bottomRight` |
+| `width`, `height` | Points. Height is a **floor**, not a size — see `richAmbientHeight` |
+| `moveable` | `true` / `false` |
+| `auto_dismiss_after` | Seconds |
+| `screen_blur_enabled` | `true` / `false` |
+| `screen_blur_intensity` | `light`, `medium`, `heavy` |
+
+#### Two behaviours that surprise people
+
+**A task timer forces `.interrupt`, whatever `screen_blur_enabled` says.**
+`RichNotification.effectiveTaskTimer` returns `nil` in `.ambient` by design — a
+labelled ring reads as a task, and ambient alerts have none — so an action that
+set `task_timer_seconds` with `screen_blur_enabled: false` would otherwise get
+no ring at all and no error to explain why. A duration the author explicitly
+asked for is a stronger signal than a blur flag that may just be an
+unconsidered default, so the mode is upgraded rather than the ring dropped. The
+upgrade is logged.
+
+**`auto_dismiss_after` is ignored while a task timer is present.** The two are
+sequential phases in VibeNotify, not a race: the dismiss clock only arms once
+the task hits zero, so honouring both would total `duration + delay` — the
+20-20-20 action's 20s task plus a 25s dismiss is 45 seconds on screen, which is
+very unlikely to be what an author who set a task duration meant. Instead the
+library's own `NotificationClock.completionHold` (1.5s) governs how long the
+completion label holds before the window closes. The ignored value is logged.
 
 ## Plugins (v2)
 

--- a/clients/macos-swift/VibeCare/Package.resolved
+++ b/clients/macos-swift/VibeCare/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "c2ee1f56fc8064857595bbbb5f33a715df3d09cf56914528cb118b01864c97e9",
+  "originHash" : "c4de3702f15e623fbbdd1d4beb40df8caea4200733c9a73e883aca4c6fe728bc",
   "pins" : [
     {
       "identity" : "grpc-swift",
@@ -267,8 +267,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vibecare-io/vibe-notify-macos.git",
       "state" : {
-        "revision" : "c74f2acd745eaaa2db31741b33bbcadd6bc3d664",
-        "version" : "0.0.5"
+        "revision" : "b0c7c2167481779eaf201018456ea0da1d73b3e6",
+        "version" : "0.0.6"
       }
     }
   ],

--- a/clients/macos-swift/VibeCare/Package.swift
+++ b/clients/macos-swift/VibeCare/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
     // Core package (contains OpenTelemetryApi and OpenTelemetrySdk)
     .package(url: "https://github.com/open-telemetry/opentelemetry-swift-core.git", from: "2.2.0"),
     // customized notification
-    .package(url: "https://github.com/vibecare-io/vibe-notify-macos.git", from: "0.0.5"),
+    .package(url: "https://github.com/vibecare-io/vibe-notify-macos.git", from: "0.0.6"),
   ],
   targets: [
     .target(

--- a/clients/macos-swift/VibeCare/VibeCare/Models/NotificationPreferences.swift
+++ b/clients/macos-swift/VibeCare/VibeCare/Models/NotificationPreferences.swift
@@ -149,6 +149,12 @@ final class NotificationPreferences: Codable, Equatable, Hashable {
 
     // MARK: - Default Presets
 
+    /// **No longer the fallback for schedule notifications.** That role belongs
+    /// to `GlobalNotificationSettings`, which the user can actually change; this
+    /// remains only as the "Default" entry in the quick-preset row and as the
+    /// base the plugin alert path fills its gaps from
+    /// (`PluginAlertAppearance`), where an appearance arrives from the plugin
+    /// and is deliberately not user-configurable.
     nonisolated(unsafe) static let `default` = NotificationPreferences(
         position: .center,
         width: 450,

--- a/clients/macos-swift/VibeCare/VibeCare/Models/NotificationPreferences.swift
+++ b/clients/macos-swift/VibeCare/VibeCare/Models/NotificationPreferences.swift
@@ -70,6 +70,22 @@ final class NotificationPreferences: Codable, Equatable, Hashable {
     var autoDismissAfter: TimeInterval? // Duration in seconds before auto-dismiss
     var screenBlurEnabled: Bool // Enable/disable screen blur background
     var screenBlurIntensity: BlurIntensity // Blur intensity level (VibeNotify 0.0.5+)
+    /// The large, legible countdown ring's duration, in seconds. `nil` (the
+    /// default, and what every action predating this field decodes to) means
+    /// no task timer at all — today's behaviour, unchanged. Sourced from an
+    /// action's `task_timer_seconds` parameter; see
+    /// `VibeNotifyConfig.showNotification` for how it becomes a VibeNotify
+    /// `TaskTimer`.
+    var taskTimerSeconds: TimeInterval?
+    /// The word under the ring's number, e.g. "seconds". Defaulted at the
+    /// point of use (`VibeNotifyConfig`), not here, so `nil` unambiguously
+    /// means "the action didn't say" rather than baking a default into the
+    /// model.
+    var taskTimerUnitLabel: String?
+    /// What the ring's centre says once the task reaches zero, e.g. "Break
+    /// complete". Never shown for an early Done or a Skip — see
+    /// `RichNotification.completionState`.
+    var taskTimerCompletionLabel: String?
 
     init(
         bundledIconId: String? = nil,
@@ -84,7 +100,10 @@ final class NotificationPreferences: Codable, Equatable, Hashable {
         moveable: Bool = true,
         autoDismissAfter: TimeInterval? = 20.0,
         screenBlurEnabled: Bool = false,
-        screenBlurIntensity: BlurIntensity = .medium
+        screenBlurIntensity: BlurIntensity = .medium,
+        taskTimerSeconds: TimeInterval? = nil,
+        taskTimerUnitLabel: String? = nil,
+        taskTimerCompletionLabel: String? = nil
     ) {
         self.bundledIconId = bundledIconId
         self.svgPath = svgPath
@@ -99,6 +118,9 @@ final class NotificationPreferences: Codable, Equatable, Hashable {
         self.autoDismissAfter = autoDismissAfter
         self.screenBlurEnabled = screenBlurEnabled
         self.screenBlurIntensity = screenBlurIntensity
+        self.taskTimerSeconds = taskTimerSeconds
+        self.taskTimerUnitLabel = taskTimerUnitLabel
+        self.taskTimerCompletionLabel = taskTimerCompletionLabel
     }
 
     /// Returns an independent copy of these preferences (a distinct reference,
@@ -118,7 +140,10 @@ final class NotificationPreferences: Codable, Equatable, Hashable {
             moveable: moveable,
             autoDismissAfter: autoDismissAfter,
             screenBlurEnabled: screenBlurEnabled,
-            screenBlurIntensity: screenBlurIntensity
+            screenBlurIntensity: screenBlurIntensity,
+            taskTimerSeconds: taskTimerSeconds,
+            taskTimerUnitLabel: taskTimerUnitLabel,
+            taskTimerCompletionLabel: taskTimerCompletionLabel
         )
     }
 
@@ -254,7 +279,10 @@ final class NotificationPreferences: Codable, Equatable, Hashable {
             lhs.moveable == rhs.moveable &&
             lhs.autoDismissAfter == rhs.autoDismissAfter &&
             lhs.screenBlurEnabled == rhs.screenBlurEnabled &&
-            lhs.screenBlurIntensity == rhs.screenBlurIntensity
+            lhs.screenBlurIntensity == rhs.screenBlurIntensity &&
+            lhs.taskTimerSeconds == rhs.taskTimerSeconds &&
+            lhs.taskTimerUnitLabel == rhs.taskTimerUnitLabel &&
+            lhs.taskTimerCompletionLabel == rhs.taskTimerCompletionLabel
     }
 
     // MARK: - Hashable
@@ -272,6 +300,9 @@ final class NotificationPreferences: Codable, Equatable, Hashable {
         hasher.combine(autoDismissAfter)
         hasher.combine(screenBlurEnabled)
         hasher.combine(screenBlurIntensity)
+        hasher.combine(taskTimerSeconds)
+        hasher.combine(taskTimerUnitLabel)
+        hasher.combine(taskTimerCompletionLabel)
     }
 }
 

--- a/clients/macos-swift/VibeCare/VibeCare/Services/GlobalNotificationSettings.swift
+++ b/clients/macos-swift/VibeCare/VibeCare/Services/GlobalNotificationSettings.swift
@@ -1,0 +1,406 @@
+import Foundation
+import SwiftUI
+import VibeNotify
+
+/// The user's **global** notification appearance — the layer every schedule
+/// alert falls back to when its action says nothing about how it should look.
+///
+/// This replaces `NotificationPreferences.default`, a hardcoded struct that
+/// nobody could change, as the bottom of the resolution stack. The order is:
+///
+/// 1. `GlobalNotificationSettings` — these values, set once in Settings.
+/// 2. The action's own `parameters` — any appearance key present wins over the
+///    global value for that key alone, never for the whole set.
+///
+/// So an action that specifies nothing gets the global look, and an action that
+/// specifies `position: topRight` keeps `topRight` and inherits everything else.
+/// `resolving(actionParameters:)` is the single place that rule is expressed.
+///
+/// ## Where these live
+///
+/// The durable copy is `Profile.preferences`, already a `map<string, string>`
+/// on the wire (`proto/vibecare.proto`) and already round-tripped by
+/// `ProfileService`, so this needed no proto change, no migration and no
+/// backend work — and it syncs across devices instead of being stranded in one
+/// machine's `UserDefaults`.
+///
+/// `UserDefaults` is still written, as a **mirror rather than a second source
+/// of truth**: notifications can fire before the profile has finished loading
+/// (and while the backend is unreachable), and reading them must not be async
+/// or main-actor-bound. `hydrate(from:)` overwrites the mirror whenever a
+/// profile arrives, so the server always wins on a conflict.
+struct GlobalNotificationSettings: Equatable, Sendable {
+
+  // MARK: - Stored
+
+  var position: NotificationPosition
+  var width: CGFloat
+  var height: CGFloat
+  var screenBlurEnabled: Bool
+  var screenBlurIntensity: BlurIntensity
+  /// Opacity of the black backdrop behind the blur, for `.interrupt` alerts
+  /// only — an `.ambient` alert builds no backdrop window at all, so this is
+  /// inert for one. See `screenDimRange` for why the bounds are what they are.
+  var screenDim: Double
+  var autoDismissAfter: TimeInterval
+  var moveable: Bool
+  /// The word under a break countdown's number, used when an action sets
+  /// `task_timer_seconds` without saying what to call the unit.
+  var breakUnitLabel: String
+  /// What a break countdown's centre says once it reaches zero.
+  var breakCompletionLabel: String
+
+  // MARK: - Bounds
+
+  /// The range the dim slider may offer, mirroring
+  /// `OverlayWindowManager.Configuration`'s own clamp (`0.1...0.95`) so the UI
+  /// can never propose a value the library would silently rewrite. The floor is
+  /// the minimum background alpha the private CGS blur call needs to composite
+  /// at all; the ceiling stops short of an opaque backdrop, which would no
+  /// longer read as a blur.
+  static let screenDimRange: ClosedRange<Double> = 0.1...0.95
+
+  /// The smallest dim at which white text is guaranteed to clear WCAG AA
+  /// (4.5:1) over *any* desktop, worst case a pure white one. Derived once, in
+  /// the library, as `Legibility.safeDim` — read from there rather than written
+  /// as `0.55` so the two cannot drift.
+  static let wcagSafeScreenDim: Double = Legibility.safeDim
+
+  // MARK: - Init
+
+  /// Spelled out because declaring `init(profilePreferences:)` below suppresses
+  /// the synthesized memberwise initializer.
+  init(
+    position: NotificationPosition,
+    width: CGFloat,
+    height: CGFloat,
+    screenBlurEnabled: Bool,
+    screenBlurIntensity: BlurIntensity,
+    screenDim: Double,
+    autoDismissAfter: TimeInterval,
+    moveable: Bool,
+    breakUnitLabel: String,
+    breakCompletionLabel: String
+  ) {
+    self.position = position
+    self.width = width
+    self.height = height
+    self.screenBlurEnabled = screenBlurEnabled
+    self.screenBlurIntensity = screenBlurIntensity
+    self.screenDim = screenDim
+    self.autoDismissAfter = autoDismissAfter
+    self.moveable = moveable
+    self.breakUnitLabel = breakUnitLabel
+    self.breakCompletionLabel = breakCompletionLabel
+  }
+
+  // MARK: - Fallback
+
+  /// What a profile that has never been to the Settings screen gets. These are
+  /// the values `NotificationPreferences.default` carried, with one addition:
+  /// `screenDim` starts at the WCAG-safe threshold rather than at the library's
+  /// floor, because an alert nobody can read is not a defensible default.
+  static let fallback = GlobalNotificationSettings(
+    position: .center,
+    width: 450,
+    height: 220,
+    screenBlurEnabled: false,
+    screenBlurIntensity: .medium,
+    screenDim: wcagSafeScreenDim,
+    autoDismissAfter: 20,
+    moveable: true,
+    breakUnitLabel: "seconds",
+    breakCompletionLabel: "Break complete"
+  )
+
+  // MARK: - Keys
+
+  /// One key list, used for both `Profile.preferences` and the `UserDefaults`
+  /// mirror. Namespaced so the profile map stays legible next to whatever else
+  /// ends up in it.
+  private enum Key {
+    static let position = "notify.position"
+    static let width = "notify.width"
+    static let height = "notify.height"
+    static let blurEnabled = "notify.blur_enabled"
+    static let blurIntensity = "notify.blur_intensity"
+    static let screenDim = "notify.screen_dim"
+    static let autoDismissAfter = "notify.auto_dismiss_after"
+    static let moveable = "notify.moveable"
+    static let breakUnitLabel = "notify.break_unit_label"
+    static let breakCompletionLabel = "notify.break_completion_label"
+
+    static let prefix = "notify."
+  }
+
+  /// The action-parameter keys that count as *appearance*, i.e. the ones a
+  /// per-action override owns and the ones the action editor's Advanced
+  /// disclosure writes or removes as a set.
+  ///
+  /// Content keys (`title`, `body`, `svg_path`, `svg_width`, `svg_height`,
+  /// `task_timer_seconds`) are deliberately absent: they are what the action is
+  /// *about*, not how it looks, and they have no global counterpart.
+  static let appearanceParameterKeys = [
+    "position", "width", "height", "moveable",
+    "auto_dismiss_after", "screen_blur_enabled", "screen_blur_intensity",
+  ]
+
+  /// Whether these parameters override the global appearance at all. The
+  /// presence of the keys *is* the persisted override state — there is no
+  /// separate "overridden" flag to keep in sync with them, and an action
+  /// authored by the CLI or MCP that sets only `position` reads correctly here
+  /// without having been written by this app.
+  static func overridesAppearance(_ parameters: [String: String]) -> Bool {
+    appearanceParameterKeys.contains { parameters[$0] != nil }
+  }
+
+  /// `parameters` with every appearance key removed, i.e. an action that
+  /// inherits the global look entirely.
+  static func clearingAppearance(_ parameters: [String: String]) -> [String: String] {
+    var result = parameters
+    for key in appearanceParameterKeys { result.removeValue(forKey: key) }
+    return result
+  }
+
+  // MARK: - Reading
+
+  /// The settings in force right now, read from the mirror. Cheap, synchronous
+  /// and callable from any isolation — which is the whole reason the mirror
+  /// exists (see the type's doc comment).
+  static var current: GlobalNotificationSettings {
+    let defaults = UserDefaults.standard
+    var settings = fallback
+
+    if let raw = defaults.string(forKey: Key.position),
+      let position = NotificationPosition(rawValue: raw)
+    {
+      settings.position = position
+    }
+    if defaults.object(forKey: Key.width) != nil {
+      settings.width = CGFloat(defaults.double(forKey: Key.width))
+    }
+    if defaults.object(forKey: Key.height) != nil {
+      settings.height = CGFloat(defaults.double(forKey: Key.height))
+    }
+    if defaults.object(forKey: Key.blurEnabled) != nil {
+      settings.screenBlurEnabled = defaults.bool(forKey: Key.blurEnabled)
+    }
+    if let raw = defaults.string(forKey: Key.blurIntensity),
+      let intensity = BlurIntensity(rawValue: raw)
+    {
+      settings.screenBlurIntensity = intensity
+    }
+    if defaults.object(forKey: Key.screenDim) != nil {
+      settings.screenDim = defaults.double(forKey: Key.screenDim)
+    }
+    if defaults.object(forKey: Key.autoDismissAfter) != nil {
+      settings.autoDismissAfter = defaults.double(forKey: Key.autoDismissAfter)
+    }
+    if defaults.object(forKey: Key.moveable) != nil {
+      settings.moveable = defaults.bool(forKey: Key.moveable)
+    }
+    if let label = defaults.string(forKey: Key.breakUnitLabel), !label.isEmpty {
+      settings.breakUnitLabel = label
+    }
+    if let label = defaults.string(forKey: Key.breakCompletionLabel), !label.isEmpty {
+      settings.breakCompletionLabel = label
+    }
+
+    return settings.sanitized
+  }
+
+  /// Bounds enforced on the way *out* as well as on the way in: a value written
+  /// by an older build, another device, or a hand-edited profile map still has
+  /// to be one the renderer can use.
+  private var sanitized: GlobalNotificationSettings {
+    var copy = self
+    copy.screenDim = min(max(screenDim, Self.screenDimRange.lowerBound), Self.screenDimRange.upperBound)
+    copy.width = max(200, width)
+    copy.height = max(120, height)
+    copy.autoDismissAfter = max(1, autoDismissAfter)
+    if copy.breakUnitLabel.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+      copy.breakUnitLabel = Self.fallback.breakUnitLabel
+    }
+    if copy.breakCompletionLabel.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+      copy.breakCompletionLabel = Self.fallback.breakCompletionLabel
+    }
+    return copy
+  }
+
+  // MARK: - Profile round trip
+
+  /// Reads whatever this profile has stored, leaving anything it never wrote at
+  /// the fallback value.
+  init(profilePreferences: [String: String]) {
+    var settings = Self.fallback
+
+    if let raw = profilePreferences[Key.position],
+      let position = NotificationPosition(rawValue: raw)
+    {
+      settings.position = position
+    }
+    if let value = profilePreferences[Key.width].flatMap(Double.init) {
+      settings.width = CGFloat(value)
+    }
+    if let value = profilePreferences[Key.height].flatMap(Double.init) {
+      settings.height = CGFloat(value)
+    }
+    if let value = profilePreferences[Key.blurEnabled].flatMap(Bool.init) {
+      settings.screenBlurEnabled = value
+    }
+    if let raw = profilePreferences[Key.blurIntensity],
+      let intensity = BlurIntensity(rawValue: raw)
+    {
+      settings.screenBlurIntensity = intensity
+    }
+    if let value = profilePreferences[Key.screenDim].flatMap(Double.init) {
+      settings.screenDim = value
+    }
+    if let value = profilePreferences[Key.autoDismissAfter].flatMap(Double.init) {
+      settings.autoDismissAfter = value
+    }
+    if let value = profilePreferences[Key.moveable].flatMap(Bool.init) {
+      settings.moveable = value
+    }
+    if let label = profilePreferences[Key.breakUnitLabel], !label.isEmpty {
+      settings.breakUnitLabel = label
+    }
+    if let label = profilePreferences[Key.breakCompletionLabel], !label.isEmpty {
+      settings.breakCompletionLabel = label
+    }
+
+    self = settings.sanitized
+  }
+
+  /// These settings as `Profile.preferences` entries, ready to be merged into
+  /// whatever else the profile carries. Every key is always written, so a
+  /// value returned to its default still propagates to the other devices
+  /// rather than silently inheriting theirs.
+  var profileEntries: [String: String] {
+    let settings = sanitized
+    return [
+      Key.position: settings.position.rawValue,
+      Key.width: String(Double(settings.width)),
+      Key.height: String(Double(settings.height)),
+      Key.blurEnabled: String(settings.screenBlurEnabled),
+      Key.blurIntensity: settings.screenBlurIntensity.rawValue,
+      Key.screenDim: String(settings.screenDim),
+      Key.autoDismissAfter: String(settings.autoDismissAfter),
+      Key.moveable: String(settings.moveable),
+      Key.breakUnitLabel: settings.breakUnitLabel,
+      Key.breakCompletionLabel: settings.breakCompletionLabel,
+    ]
+  }
+
+  /// `preferences` with these settings' entries applied, leaving every
+  /// unrelated key untouched.
+  func merged(into preferences: [String: String]) -> [String: String] {
+    var result = preferences
+    for (key, value) in profileEntries { result[key] = value }
+    return result
+  }
+
+  /// Writes the mirror. Called after a successful edit and from
+  /// `hydrate(from:)`.
+  func persistLocally() {
+    let defaults = UserDefaults.standard
+    for (key, value) in profileEntries {
+      switch key {
+      case Key.width, Key.height, Key.screenDim, Key.autoDismissAfter:
+        defaults.set(Double(value) ?? 0, forKey: key)
+      case Key.blurEnabled, Key.moveable:
+        defaults.set(value == "true", forKey: key)
+      default:
+        defaults.set(value, forKey: key)
+      }
+    }
+  }
+
+  /// Adopts a freshly loaded profile's settings into the mirror.
+  ///
+  /// A profile carrying none of these keys is left alone rather than reset: it
+  /// is a profile that has never visited the Settings screen, not a profile
+  /// that asked for the defaults, and clobbering the mirror would discard
+  /// settings the user made while offline before they were ever synced.
+  static func hydrate(from profilePreferences: [String: String]) {
+    guard profilePreferences.keys.contains(where: { $0.hasPrefix(Key.prefix) }) else { return }
+    GlobalNotificationSettings(profilePreferences: profilePreferences).persistLocally()
+  }
+
+  // MARK: - Resolution
+
+  /// These settings as a `NotificationPreferences`, with no action layered on
+  /// top — what an alert with no customisation whatsoever looks like.
+  func basePreferences() -> NotificationPreferences {
+    NotificationPreferences(
+      position: position,
+      width: width,
+      height: height,
+      moveable: moveable,
+      autoDismissAfter: autoDismissAfter,
+      screenBlurEnabled: screenBlurEnabled,
+      screenBlurIntensity: screenBlurIntensity,
+      // No `taskTimerSeconds`: a break countdown is something an action asks
+      // for. These two only say what to *call* it when one does.
+      taskTimerUnitLabel: breakUnitLabel,
+      taskTimerCompletionLabel: breakCompletionLabel
+    )
+  }
+
+  /// **The resolution rule.** Global settings are the defaults; any key present
+  /// in `parameters` overrides them, key by key.
+  ///
+  /// The old version of this returned `nil` unless *some* customisation
+  /// existed, which is what made an uncustomised alert fall through to the
+  /// hardcoded `NotificationPreferences.default`. That test is wrong once
+  /// globals exist: every notification now has preferences, they just may all
+  /// come from the global layer.
+  func resolving(actionParameters parameters: [String: String]) -> NotificationPreferences {
+    let preferences = basePreferences()
+
+    // Content — no global counterpart, so absent simply means absent.
+    // `svg_path` carries the full URL for bundled icons and a file path for
+    // custom ones; there is no separate bundled-id parameter any more.
+    preferences.svgPath = parameters["svg_path"]
+    preferences.svgWidth = parameters["svg_width"].flatMap(Double.init).map { CGFloat($0) }
+    preferences.svgHeight = parameters["svg_height"].flatMap(Double.init).map { CGFloat($0) }
+    preferences.title = parameters["title"]
+    preferences.message = parameters["body"]
+
+    // Appearance — global unless this action says otherwise.
+    if let raw = parameters["position"], let value = NotificationPosition(rawValue: raw) {
+      preferences.position = value
+    }
+    if let value = parameters["width"].flatMap(Double.init) {
+      preferences.width = CGFloat(value)
+    }
+    if let value = parameters["height"].flatMap(Double.init) {
+      preferences.height = CGFloat(value)
+    }
+    if let value = parameters["moveable"].flatMap(Bool.init) {
+      preferences.moveable = value
+    }
+    if let value = parameters["auto_dismiss_after"].flatMap(Double.init) {
+      preferences.autoDismissAfter = value
+    }
+    if let value = parameters["screen_blur_enabled"].flatMap(Bool.init) {
+      preferences.screenBlurEnabled = value
+    }
+    if let raw = parameters["screen_blur_intensity"], let value = BlurIntensity(rawValue: raw) {
+      preferences.screenBlurIntensity = value
+    }
+
+    // Break countdown: the duration is the action's alone (absent or
+    // unparseable means no ring at all, unchanged), the labels fall back to the
+    // global ones already seeded by `basePreferences()`.
+    preferences.taskTimerSeconds = parameters["task_timer_seconds"].flatMap(Double.init)
+    if let label = parameters["task_timer_unit_label"], !label.isEmpty {
+      preferences.taskTimerUnitLabel = label
+    }
+    if let label = parameters["task_timer_completion_label"], !label.isEmpty {
+      preferences.taskTimerCompletionLabel = label
+    }
+
+    return preferences
+  }
+}

--- a/clients/macos-swift/VibeCare/VibeCare/Services/GlobalNotificationSettings.swift
+++ b/clients/macos-swift/VibeCare/VibeCare/Services/GlobalNotificationSettings.swift
@@ -42,6 +42,17 @@ struct GlobalNotificationSettings: Equatable, Sendable {
   /// only — an `.ambient` alert builds no backdrop window at all, so this is
   /// inert for one. See `screenDimRange` for why the bounds are what they are.
   var screenDim: Double
+  /// What a full-screen alert puts behind itself: the user's own desktop
+  /// blurred and dimmed (the default, and what every alert did before this
+  /// existed), or one of the flat/gradient fields the library paints instead.
+  ///
+  /// Global-only, deliberately: there is no per-action override key for it and
+  /// it is absent from `appearanceParameterKeys`. A break backdrop is a
+  /// property of *this machine's* idea of restful, not of the routine that
+  /// fired the alert, and every option is luminance-capped by the library
+  /// (`Legibility.maxSafeLuminance`) so there is no unsafe value for an action
+  /// to smuggle in anyway.
+  var backdropStyle: BackdropStyle
   var autoDismissAfter: TimeInterval
   var moveable: Bool
   /// The word under a break countdown's number, used when an action sets
@@ -77,6 +88,7 @@ struct GlobalNotificationSettings: Equatable, Sendable {
     screenBlurEnabled: Bool,
     screenBlurIntensity: BlurIntensity,
     screenDim: Double,
+    backdropStyle: BackdropStyle = .blurredDesktop,
     autoDismissAfter: TimeInterval,
     moveable: Bool,
     breakUnitLabel: String,
@@ -88,6 +100,7 @@ struct GlobalNotificationSettings: Equatable, Sendable {
     self.screenBlurEnabled = screenBlurEnabled
     self.screenBlurIntensity = screenBlurIntensity
     self.screenDim = screenDim
+    self.backdropStyle = backdropStyle
     self.autoDismissAfter = autoDismissAfter
     self.moveable = moveable
     self.breakUnitLabel = breakUnitLabel
@@ -107,6 +120,9 @@ struct GlobalNotificationSettings: Equatable, Sendable {
     screenBlurEnabled: false,
     screenBlurIntensity: .medium,
     screenDim: wcagSafeScreenDim,
+    // The blurred desktop, i.e. nothing about an existing alert changes until
+    // the user picks something else.
+    backdropStyle: .blurredDesktop,
     autoDismissAfter: 20,
     moveable: true,
     breakUnitLabel: "seconds",
@@ -125,6 +141,7 @@ struct GlobalNotificationSettings: Equatable, Sendable {
     static let blurEnabled = "notify.blur_enabled"
     static let blurIntensity = "notify.blur_intensity"
     static let screenDim = "notify.screen_dim"
+    static let backdropStyle = "notify.backdrop_style"
     static let autoDismissAfter = "notify.auto_dismiss_after"
     static let moveable = "notify.moveable"
     static let breakUnitLabel = "notify.break_unit_label"
@@ -193,6 +210,11 @@ struct GlobalNotificationSettings: Equatable, Sendable {
     if defaults.object(forKey: Key.screenDim) != nil {
       settings.screenDim = defaults.double(forKey: Key.screenDim)
     }
+    if let raw = defaults.string(forKey: Key.backdropStyle),
+      let style = BackdropStyle(rawValue: raw)
+    {
+      settings.backdropStyle = style
+    }
     if defaults.object(forKey: Key.autoDismissAfter) != nil {
       settings.autoDismissAfter = defaults.double(forKey: Key.autoDismissAfter)
     }
@@ -256,6 +278,15 @@ struct GlobalNotificationSettings: Equatable, Sendable {
     if let value = profilePreferences[Key.screenDim].flatMap(Double.init) {
       settings.screenDim = value
     }
+    // An unknown raw value — a style this build does not have, written by a
+    // newer one on another device — falls back to the blurred desktop rather
+    // than failing the whole hydration. Every option is safe; none is
+    // load-bearing.
+    if let raw = profilePreferences[Key.backdropStyle],
+      let style = BackdropStyle(rawValue: raw)
+    {
+      settings.backdropStyle = style
+    }
     if let value = profilePreferences[Key.autoDismissAfter].flatMap(Double.init) {
       settings.autoDismissAfter = value
     }
@@ -285,6 +316,7 @@ struct GlobalNotificationSettings: Equatable, Sendable {
       Key.blurEnabled: String(settings.screenBlurEnabled),
       Key.blurIntensity: settings.screenBlurIntensity.rawValue,
       Key.screenDim: String(settings.screenDim),
+      Key.backdropStyle: settings.backdropStyle.rawValue,
       Key.autoDismissAfter: String(settings.autoDismissAfter),
       Key.moveable: String(settings.moveable),
       Key.breakUnitLabel: settings.breakUnitLabel,

--- a/clients/macos-swift/VibeCare/VibeCare/Services/NotificationManager.swift
+++ b/clients/macos-swift/VibeCare/VibeCare/Services/NotificationManager.swift
@@ -34,8 +34,11 @@ class NotificationManager: NSObject, ObservableObject {
 
         let scheduledTime = event.hasScheduledTime ? event.scheduledTime.date : Date()
 
-        // Note: Notification preferences are now stored per-action, not at schedule level
-        // For basic schedule notifications (without specific actions), use default preferences
+        // Notification preferences are stored per-action, not at schedule
+        // level. A bare schedule notification has no action to read, so it gets
+        // the global layer alone — `nil` here, which
+        // `VibeNotifyConfig.showScheduleNotification` resolves to
+        // `GlobalNotificationSettings.current.basePreferences()`.
         let notificationPreferences: NotificationPreferences? = nil
 
         let notificationID = VibeNotifyConfig.showScheduleNotification(
@@ -148,51 +151,20 @@ class NotificationManager: NSObject, ObservableObject {
 
     // MARK: - Helper Methods
 
-    /// Deserialize notification preferences from action parameters
-    private func deserializeNotificationPreferences(from params: [String: String]) -> NotificationPreferences? {
-        // Create notification preferences from parameters
-        // Only read svg_path (contains full URL for both bundled and custom icons)
-        let svgPath = params["svg_path"]
-        let svgWidth = params["svg_width"].flatMap { Double($0) }.map { CGFloat($0) }
-        let svgHeight = params["svg_height"].flatMap { Double($0) }.map { CGFloat($0) }
-        let title = params["title"]
-        let message = params["body"]
-        let position = params["position"].flatMap { NotificationPosition(rawValue: $0) } ?? .center
-        let width = params["width"].flatMap { Double($0) }.map { CGFloat($0) }
-        let height = params["height"].flatMap { Double($0) }.map { CGFloat($0) }
-        let moveable = params["moveable"].flatMap { Bool($0) } ?? true
-        let autoDismissAfter = params["auto_dismiss_after"].flatMap { Double($0) }
-        let screenBlurEnabled = params["screen_blur_enabled"].flatMap { Bool($0) } ?? false
-        let screenBlurIntensity = params["screen_blur_intensity"].flatMap { BlurIntensity(rawValue: $0) } ?? .medium
-        // Absent or unparseable means no task timer — today's behaviour,
-        // unchanged (see `NotificationPreferences.taskTimerSeconds`).
-        let taskTimerSeconds = params["task_timer_seconds"].flatMap { Double($0) }
-        let taskTimerUnitLabel = params["task_timer_unit_label"]
-        let taskTimerCompletionLabel = params["task_timer_completion_label"]
-
-        // Only return preferences if at least some customization exists
-        // Otherwise return nil to use default notification appearance
-        if svgPath != nil || width != nil || height != nil || position != .center || screenBlurEnabled || taskTimerSeconds != nil {
-            return NotificationPreferences(
-                bundledIconId: nil, // Always nil now - IDs converted to URLs
-                svgPath: svgPath,
-                svgWidth: svgWidth,
-                svgHeight: svgHeight,
-                title: title,
-                message: message,
-                position: position,
-                width: width,
-                height: height,
-                moveable: moveable,
-                autoDismissAfter: autoDismissAfter,
-                screenBlurEnabled: screenBlurEnabled,
-                screenBlurIntensity: screenBlurIntensity,
-                taskTimerSeconds: taskTimerSeconds,
-                taskTimerUnitLabel: taskTimerUnitLabel,
-                taskTimerCompletionLabel: taskTimerCompletionLabel
-            )
-        }
-
-        return nil
+    /// Resolve an action's notification preferences: the user's global settings
+    /// as defaults, with any appearance key the action sets winning over them.
+    ///
+    /// This used to build preferences purely from `params` and return `nil`
+    /// unless *some* customisation existed — that `nil` is what made an
+    /// uncustomised alert fall back to the hardcoded
+    /// `NotificationPreferences.default`. Both halves are gone: the fallback is
+    /// now the user's global settings, and the "is anything customised?" test
+    /// is meaningless once every notification has preferences (they just may
+    /// all come from the global layer). Hence the non-optional return.
+    ///
+    /// The rule itself lives in `GlobalNotificationSettings.resolving(actionParameters:)`
+    /// so the action editor and this delivery path cannot disagree about it.
+    private func deserializeNotificationPreferences(from params: [String: String]) -> NotificationPreferences {
+        GlobalNotificationSettings.current.resolving(actionParameters: params)
     }
 }

--- a/clients/macos-swift/VibeCare/VibeCare/Services/NotificationManager.swift
+++ b/clients/macos-swift/VibeCare/VibeCare/Services/NotificationManager.swift
@@ -164,10 +164,15 @@ class NotificationManager: NSObject, ObservableObject {
         let autoDismissAfter = params["auto_dismiss_after"].flatMap { Double($0) }
         let screenBlurEnabled = params["screen_blur_enabled"].flatMap { Bool($0) } ?? false
         let screenBlurIntensity = params["screen_blur_intensity"].flatMap { BlurIntensity(rawValue: $0) } ?? .medium
+        // Absent or unparseable means no task timer — today's behaviour,
+        // unchanged (see `NotificationPreferences.taskTimerSeconds`).
+        let taskTimerSeconds = params["task_timer_seconds"].flatMap { Double($0) }
+        let taskTimerUnitLabel = params["task_timer_unit_label"]
+        let taskTimerCompletionLabel = params["task_timer_completion_label"]
 
         // Only return preferences if at least some customization exists
         // Otherwise return nil to use default notification appearance
-        if svgPath != nil || width != nil || height != nil || position != .center || screenBlurEnabled {
+        if svgPath != nil || width != nil || height != nil || position != .center || screenBlurEnabled || taskTimerSeconds != nil {
             return NotificationPreferences(
                 bundledIconId: nil, // Always nil now - IDs converted to URLs
                 svgPath: svgPath,
@@ -181,7 +186,10 @@ class NotificationManager: NSObject, ObservableObject {
                 moveable: moveable,
                 autoDismissAfter: autoDismissAfter,
                 screenBlurEnabled: screenBlurEnabled,
-                screenBlurIntensity: screenBlurIntensity
+                screenBlurIntensity: screenBlurIntensity,
+                taskTimerSeconds: taskTimerSeconds,
+                taskTimerUnitLabel: taskTimerUnitLabel,
+                taskTimerCompletionLabel: taskTimerCompletionLabel
             )
         }
 

--- a/clients/macos-swift/VibeCare/VibeCare/Services/ProfileService.swift
+++ b/clients/macos-swift/VibeCare/VibeCare/Services/ProfileService.swift
@@ -123,6 +123,15 @@ public final class ProfileService: @unchecked Sendable {
                 request.name = profile.name
                 request.email = profile.email ?? ""  // Convert nil to empty string for protobuf
                 request.timezone = profile.timezone
+                // `UpdateProfileRequest.preferences` has existed on the wire
+                // since the first version of the proto (`vibecare.proto:237`)
+                // and the server persists it (`profile_service.go`, UpdateProfile:
+                // `if len(req.Preferences) > 0 { profile.Preferences = ... }`),
+                // but this client never filled it in — so every preference the
+                // UI edited was dropped on the way out. Global notification
+                // settings ride in this map; without this line they would round
+                // trip locally and silently reset on the next profile load.
+                request.preferences = profile.preferences
 
                 let clientRequest = ClientRequest(message: request)
                 let updatedVCProfile = try await client.updateProfile(

--- a/clients/macos-swift/VibeCare/VibeCare/Services/VibeNotifyConfiguration.swift
+++ b/clients/macos-swift/VibeCare/VibeCare/Services/VibeNotifyConfiguration.swift
@@ -64,8 +64,8 @@ enum VibeNotifyConfig {
   /// rather than growing the window — deliberately, because an
   /// `NSHostingView` free to publish its content's height resized an `.ambient`
   /// window to 2289pt tall. Every authored height in this app predates that
-  /// renderer: they were chosen against one with no 28pt content padding, no
-  /// 26pt title and no half-height illustration cap. At the default 450x220 the
+  /// renderer: they were chosen against one with no content padding, no
+  /// set title and no half-height illustration cap. At the default 450x220 the
   /// rich renderer clips its own illustration at the top and everything below
   /// the message at the bottom. So an authored height is a floor, not a size.
   ///
@@ -87,17 +87,28 @@ enum VibeNotifyConfig {
   /// were 248pt of chrome without a button row and 286pt with one. Both worst
   /// cases are a five-line message, which is not hypothetical: it is what the
   /// customization sheet's preview substitutes when no message is set.
+  ///
+  /// **Re-measured after the renderer's ambient type and spacing scale changed**
+  /// (VibeNotify `RichMetrics.ambient`: 22pt padding, a 19pt title, a 13pt
+  /// message and grouped rather than uniform gaps, replacing a flat 28/26/15/22).
+  /// The same sweep now yields 248 without buttons and **276** with them — the
+  /// stack got tighter, so both constants below remain floors with room to
+  /// spare and neither is changed. Only this prose was stale: it described the
+  /// old scale, and a comment that names four numbers none of which the renderer
+  /// still uses is worse than no comment.
   static func richAmbientHeight(illustrationHeight: CGFloat, hasButtons: Bool) -> CGFloat {
     let chrome = hasButtons ? richChromeWithButtons : richChrome
     return chrome + min(illustrationHeight, chrome)
   }
 
   /// Room for everything the rich renderer draws that is not the illustration:
-  /// 28pt of padding top and bottom, a 26pt title, the message, 22pt between
-  /// each element, and the dismiss clock's own row. Measured worst case 248 (see
-  /// above); the margin is for a message longer than any measured.
+  /// the content padding, the title, the message, the gaps between elements and
+  /// the dismiss clock's own row — all of them now sourced from VibeNotify's
+  /// `RichMetrics.ambient` rather than from literals repeated here. Measured
+  /// worst case 248 (see above); the margin is for a message longer than any
+  /// measured.
   private static let richChrome: CGFloat = 264
-  /// `richChrome` with a row of action buttons — measured worst case 286.
+  /// `richChrome` with a row of action buttons — measured worst case 276.
   private static let richChromeWithButtons: CGFloat = 304
 
   // MARK: - Schedule Notification

--- a/clients/macos-swift/VibeCare/VibeCare/Services/VibeNotifyConfiguration.swift
+++ b/clients/macos-swift/VibeCare/VibeCare/Services/VibeNotifyConfiguration.swift
@@ -308,7 +308,14 @@ enum VibeNotifyConfig {
       configuration: configuration,
       countdown: notification.countdown
     ) {
-      RichNotificationView(notification: notification, effectiveDim: effectiveDim) {
+      RichNotificationView(
+        notification: notification,
+        effectiveDim: effectiveDim,
+        // Off the configuration the backdrop window is built from, never a
+        // second read of the settings: the window and the renderer have to
+        // agree about what is behind the text.
+        backdropStyle: configuration.backdropStyle
+      ) {
         OverlayWindowManager.shared.dismiss(id: id)
       }
     }
@@ -335,7 +342,12 @@ enum VibeNotifyConfig {
     height: CGFloat
   ) -> (OverlayWindowManager.Configuration, Double) {
     let reduceTransparency = Legibility.Accessibility.reduceTransparency
-    let backdrop = Legibility.backdrop(for: mode, reduceTransparency: reduceTransparency)
+    // The user's chosen break backdrop is global, like the dim beside it, and
+    // is read from the same place for the same reason: it is not something an
+    // action can override, so it never rides in on `prefs`.
+    let backdropStyle = GlobalNotificationSettings.current.backdropStyle
+    let backdrop = Legibility.backdrop(
+      for: mode, reduceTransparency: reduceTransparency, style: backdropStyle)
 
     switch mode {
     case .interrupt:
@@ -358,12 +370,24 @@ enum VibeNotifyConfig {
         dismissOnScreenTap: true,
         animatePresentation: true,
         screenDim: dim,
-        takesKeyFocus: true
+        takesKeyFocus: true,
+        backdropStyle: backdropStyle
       )
-      // `Configuration` clamps `screenDim` on the way in, so read it back off
-      // the configuration rather than passing the unclamped request on to the
-      // renderer — the two must agree about the same number.
-      return (configuration, isOpaque ? 1.0 : configuration.screenDim)
+      // What the renderer should believe is behind its text.
+      //
+      // A painted backdrop hides the desktop outright with a surface capped at
+      // `Legibility.maxSafeLuminance`; that is total coverage, so it reads as 1
+      // and the renderer draws no local scrim — the same conclusion it reaches
+      // over Reduce Transparency's black. Deliberately **not**
+      // `backdrop?.effectiveDim`, which would be right for those two cases and
+      // wrong for the third: `Legibility.backdrop` reports the blurred
+      // desktop's dim as the safe 0.55 it *prescribes*, not the possibly much
+      // lower one this user actually set, and handing the renderer 0.55 when
+      // the screen is dimmed to 0.2 is exactly the "no scrim needed" mistake
+      // this parameter exists to prevent. For that case the honest number is
+      // the configuration's own, read back after its clamp so the two agree.
+      let paintsOwnSurface = isOpaque || backdrop?.fill != nil
+      return (configuration, paintsOwnSurface ? 1.0 : configuration.screenDim)
 
     case .ambient:
       let configuration = OverlayWindowManager.Configuration(

--- a/clients/macos-swift/VibeCare/VibeCare/Services/VibeNotifyConfiguration.swift
+++ b/clients/macos-swift/VibeCare/VibeCare/Services/VibeNotifyConfiguration.swift
@@ -8,12 +8,12 @@ extension BlurIntensity {
     /// Convert VibeCare BlurIntensity to VibeNotify ScreenBlurIntensity.
     ///
     /// One of the three type-translation boundaries between VibeCare's own
-    /// vocabulary and VibeNotify's. Currently uncalled: both alert paths now
-    /// pick an `AlertMode`, and its factories own the backdrop — `.interrupt`
-    /// blurs heavily and dims to `Legibility.safeDim`, `.ambient` does not blur
-    /// at all. Kept because the boundary, not the call site, is the thing worth
-    /// preserving: it is where an intensity preference reconnects to a window
-    /// if the library ever exposes an intensity-taking mode.
+    /// vocabulary and VibeNotify's. Live again as of global notification
+    /// settings: `VibeNotifyConfig.windowConfiguration` hand-writes the
+    /// `.interrupt` window `Configuration` rather than taking
+    /// `AlertMode`'s factory wholesale, precisely so the user's chosen blur
+    /// intensity and screen dim reach the backdrop. `.ambient` still builds no
+    /// blur window, so intensity remains inert for that mode.
     var vibeNotifyIntensity: ScreenBlurIntensity {
         switch self {
         case .light: return .light
@@ -123,8 +123,10 @@ enum VibeNotifyConfig {
     priority: NotificationPriority = .normal,
     preferences: NotificationPreferences? = nil
   ) -> UUID? {
-    // Use custom preferences or default
-    let prefs = preferences ?? .default
+    // Use the caller's preferences, or the user's global notification settings
+    // — no longer `NotificationPreferences.default`, a hardcoded struct nobody
+    // could change. See `GlobalNotificationSettings` for the resolution order.
+    let prefs = preferences ?? GlobalNotificationSettings.current.basePreferences()
 
     logger.debug("🔍 showScheduleNotification - START", metadata: [
       "svgPath": "\(prefs.svgPath ?? "nil")",
@@ -171,29 +173,25 @@ enum VibeNotifyConfig {
       return nil
     }
 
-    var builder = VibeNotify.builder()
-
     // Illustration: SVG (url/file) if configured, else the caller's default
-    // system icon as an SF Symbol. Deliberately `.illustration(.symbol(...))`
-    // rather than `.icon(.system(...))`: the latter is a
-    // `StandardNotification.IconType`, which the rich renderer's routing does
-    // not recognise as an illustration at all, so the no-SVG case — what every
-    // unconfigured schedule gets — would render without a picture. A nil
+    // system icon as an SF Symbol. Deliberately an `Illustration.symbol(...)`
+    // rather than a `StandardNotification.IconType`: the rich renderer does not
+    // recognise the latter as an illustration at all, so the no-SVG case — what
+    // every unconfigured schedule gets — would render without a picture. A nil
     // `color` means "the title colour", i.e. whatever is legible over the
     // scrim the renderer drew.
-    if let svgPath = prefs.resolvedSVGPath, let svgSize = prefs.svgSize {
-      if svgPath.hasPrefix("http://") || svgPath.hasPrefix("https://") {
-        if let url = URL(string: svgPath) {
-          builder = builder.svgURL(url, size: svgSize)
-        } else {
-          builder = builder.illustration(.symbol(defaultSystemIcon, pointSize: fallbackSymbolPointSize, color: nil))
-        }
-      } else {
-        builder = builder.svg(svgPath, size: svgSize)
+    let fallbackIllustration = RichNotification.Illustration.symbol(
+      defaultSystemIcon, pointSize: fallbackSymbolPointSize, color: nil)
+    let illustration: RichNotification.Illustration = {
+      guard let svgPath = prefs.resolvedSVGPath, let svgSize = prefs.svgSize else {
+        return fallbackIllustration
       }
-    } else {
-      builder = builder.illustration(.symbol(defaultSystemIcon, pointSize: fallbackSymbolPointSize, color: nil))
-    }
+      if svgPath.hasPrefix("http://") || svgPath.hasPrefix("https://") {
+        guard let url = URL(string: svgPath) else { return fallbackIllustration }
+        return .svg(.url(url), size: svgSize)
+      }
+      return .svg(.filePath(svgPath), size: svgSize)
+    }()
 
     // A task-timer duration rides along on the action's parameters
     // (`task_timer_seconds`, with optional `task_timer_unit_label` /
@@ -209,38 +207,25 @@ enum VibeNotifyConfig {
       )
     }
 
-    builder = builder
-      .title(title)
-      .message(message)
-      .dismissOnScreenTap(true)
-      // The blur toggle is already the user's way of saying "take over my
-      // screen for this", so it selects the alert mode rather than a lone
-      // window knob — no new persisted key and no new control in the
-      // customization UI. `.interrupt` dims the whole screen to
-      // `Legibility.safeDim` and picks text colours against that dim; the old
-      // code pinned a light blur at 0.1 and chose text from the system
-      // appearance, which is exactly how a title landed invisible over a dark
-      // terminal.
-      //
-      // A task timer forces `.interrupt` regardless of `screenBlurEnabled`.
-      // `RichNotification.effectiveTaskTimer` returns `nil` in `.ambient` by
-      // design — a labelled ring reads as a task, and ambient alerts have
-      // none — so an action that set `task_timer_seconds` but left
-      // `screen_blur_enabled: false` would otherwise get no ring at all and
-      // no error to explain why. A duration the caller explicitly asked for
-      // is a stronger signal than a blur flag that may just be an
-      // unconsidered default, so this upgrades rather than silently drops
-      // the ring.
-      //
-      // Setting `.mode(_:)` at all is what routes this funnel to the rich
-      // renderer (see `NotificationBuilder.routesToRichRenderer`), which is
-      // also why `.moveable`, `.alwaysOnTop` and `.screenBlur(_:intensity:)`
-      // are gone from this chain: `AlertMode`'s factories own the whole
-      // window `Configuration` now, and leaving inert builder calls here
-      // would read as though the preferences still reached the window.
-      // `prefs.screenBlurIntensity` and `prefs.moveable` are consequently no
-      // longer honoured for schedule alerts.
-      .mode(taskTimer != nil || prefs.screenBlurEnabled ? .interrupt : .ambient)
+    // The blur toggle is already the user's way of saying "take over my
+    // screen for this", so it selects the alert mode rather than a lone window
+    // knob. `.interrupt` dims the whole screen and picks text colours against
+    // that dim; the old pre-rich code pinned a light blur at 0.1 and chose
+    // text from the system appearance, which is exactly how a title landed
+    // invisible over a dark terminal.
+    //
+    // A task timer forces `.interrupt` regardless of `screenBlurEnabled`.
+    // `RichNotification.effectiveTaskTimer` returns `nil` in `.ambient` by
+    // design — a labelled ring reads as a task, and ambient alerts have
+    // none — so an action that set `task_timer_seconds` but left
+    // `screen_blur_enabled: false` would otherwise get no ring at all and no
+    // error to explain why. A duration the caller explicitly asked for is a
+    // stronger signal than a blur flag that may just be an unconsidered
+    // default, so this upgrades rather than silently drops the ring.
+    let mode: AlertMode = (taskTimer != nil || prefs.screenBlurEnabled) ? .interrupt : .ambient
+
+    var buttons: [StandardNotification.Button] = []
+    var autoDismiss: StandardNotification.AutoDismiss?
 
     if let taskTimer {
       if !prefs.screenBlurEnabled {
@@ -249,10 +234,10 @@ enum VibeNotifyConfig {
           metadata: ["duration": "\(taskTimer.duration)"]
         )
       }
-      builder = builder
-        .taskTimer(taskTimer)
-        .button(StandardNotification.Button(title: "Done", style: .primary, action: {}))
-        .button(StandardNotification.Button(title: "Skip", style: .secondary, action: {}))
+      buttons = [
+        StandardNotification.Button(title: "Done", style: .primary, action: {}),
+        StandardNotification.Button(title: "Skip", style: .secondary, action: {}),
+      ]
       // `auto_dismiss_after` is deliberately NOT forwarded here. A task timer
       // and an auto-dismiss are sequential phases, not a race — the task
       // runs first and alone, and the dismiss clock only arms once it hits
@@ -270,51 +255,147 @@ enum VibeNotifyConfig {
         )
       }
     } else {
-      builder = builder.autoDismiss(after: prefs.autoDismissAfter ?? quickDismissDelay)
+      autoDismiss = StandardNotification.AutoDismiss(
+        delay: prefs.autoDismissAfter ?? quickDismissDelay, indicator: .none)
     }
 
-    switch prefs.position {
-    case .center:
-      builder = builder.position(.center)
-    case .topLeft:
-      builder = builder.position(.topLeft)
-    case .topRight:
-      builder = builder.position(.topRight)
-    case .bottomLeft:
-      builder = builder.position(.bottomLeft)
-    case .bottomRight:
-      builder = builder.position(.bottomRight)
-    }
+    let notification = RichNotification(
+      illustration: illustration,
+      title: title,
+      message: message,
+      buttons: buttons,
+      taskTimer: taskTimer,
+      autoDismiss: autoDismiss,
+      mode: mode
+    )
 
-    if let width = prefs.width {
-      builder = builder.width(CGFloat(width))
-    }
-    // The authored height is a floor — see `richAmbientHeight`. Unconditional
-    // rather than branched on the mode because `.interrupt` ignores width and
-    // height entirely (it takes the whole screen), so there is nothing for a
-    // branch to protect. `hasButtons` reserves the extra row height only for
-    // the Done/Skip pair a task timer adds — a plain schedule alert still has
-    // none.
-    builder = builder.height(
-      max(
-        CGFloat(prefs.height ?? 0),
-        richAmbientHeight(
-          // The height of the picture as the renderer will be asked to draw it.
-          // The invalid-URL branch above falls back to a symbol while `svgSize`
-          // is still set, so that one case reserves the SVG's room for a smaller
-          // symbol — over-reserving, which is the harmless direction.
-          illustrationHeight: prefs.svgSize?.height ?? fallbackSymbolPointSize,
-          hasButtons: taskTimer != nil
-        )
+    // The authored height is a floor — see `richAmbientHeight`. Computed
+    // unconditionally rather than branched on the mode because `.interrupt`
+    // ignores width and height entirely (it takes the whole screen), so there
+    // is nothing for a branch to protect. `hasButtons` reserves the extra row
+    // height only for the Done/Skip pair a task timer adds — a plain schedule
+    // alert still has none.
+    let height = max(
+      CGFloat(prefs.height ?? 0),
+      richAmbientHeight(
+        // The height of the picture as the renderer will be asked to draw it.
+        // The invalid-URL branch above falls back to a symbol while `svgSize`
+        // is still set, so that one case reserves the SVG's room for a smaller
+        // symbol — over-reserving, which is the harmless direction.
+        illustrationHeight: prefs.svgSize?.height ?? fallbackSymbolPointSize,
+        hasButtons: taskTimer != nil
       )
     )
 
-    return builder.show()
+    let (configuration, effectiveDim) = windowConfiguration(
+      mode: mode, prefs: prefs, height: height)
+
+    // `OverlayWindowManager.show` rather than `VibeNotify.shared.showRich`,
+    // for one reason: `showRich` builds `RichNotificationView` without an
+    // `effectiveDim`, so the renderer assumes whatever `AlertMode` implies —
+    // a flat `Legibility.safeDim` (0.55) for `.interrupt`. That assumption is
+    // exactly what stops being true once the dim is a user setting: at a dim
+    // of 0.2 the renderer would conclude the backdrop is already safe and skip
+    // the local feathered scrim, leaving white text over a barely-dimmed
+    // desktop. Passing the real dim is what `RichNotificationView`'s
+    // `effectiveDim` parameter exists for, and it is the only knob `showRich`
+    // does not forward. Everything else here is what `showRich` does:
+    // `notification.countdown` for the clock, `Legibility.backdrop` to decide
+    // whether the blur window should exist at all under Reduce Transparency.
+    let id = UUID()
+    OverlayWindowManager.shared.show(
+      id: id,
+      configuration: configuration,
+      countdown: notification.countdown
+    ) {
+      RichNotificationView(notification: notification, effectiveDim: effectiveDim) {
+        OverlayWindowManager.shared.dismiss(id: id)
+      }
+    }
+    return id
   }
 
-  // MARK: - Position Mapping
-  // Note: The position is set using the builder's .position() method
-  // which accepts the enum directly (e.g., .center, .topLeft, etc.)
+  // MARK: - Window Configuration
+
+  /// The window `Configuration` for `mode`, and the backdrop dim the renderer
+  /// should believe is in force.
+  ///
+  /// Hand-written memberwise literals rather than `Configuration.interrupt(...)`
+  /// / `.ambient(...)`, which is what `OverlayWindowManager.Configuration`'s own
+  /// doc comment asks consumers to do — and necessary here regardless, because
+  /// neither factory takes the two fields this feature exists to make
+  /// adjustable: `.interrupt` pins `screenDim` to `Legibility.safeDim` and
+  /// `.ambient` pins `isMoveable` to false. Every other field is copied from the
+  /// corresponding factory verbatim; see `AlertMode.swift` for why each is what
+  /// it is.
+  @MainActor
+  private static func windowConfiguration(
+    mode: AlertMode,
+    prefs: NotificationPreferences,
+    height: CGFloat
+  ) -> (OverlayWindowManager.Configuration, Double) {
+    let reduceTransparency = Legibility.Accessibility.reduceTransparency
+    let backdrop = Legibility.backdrop(for: mode, reduceTransparency: reduceTransparency)
+
+    switch mode {
+    case .interrupt:
+      // An opaque backdrop means Reduce Transparency: the renderer draws its
+      // own solid black layer, so a blur window behind it is a live, invisible
+      // no-op — the same suppression `VibeNotify.showRich` performs.
+      let isOpaque = backdrop?.isOpaque ?? false
+      let dim = GlobalNotificationSettings.current.screenDim
+      let configuration = OverlayWindowManager.Configuration(
+        presentationMode: .fullScreen,
+        position: nil,
+        width: nil,
+        height: nil,
+        backgroundColor: .clear,
+        isTransparent: true,
+        isMoveable: false,
+        alwaysOnTop: true,
+        screenBlur: !isOpaque,
+        screenBlurIntensity: prefs.screenBlurIntensity.vibeNotifyIntensity,
+        dismissOnScreenTap: true,
+        animatePresentation: true,
+        screenDim: dim,
+        takesKeyFocus: true
+      )
+      // `Configuration` clamps `screenDim` on the way in, so read it back off
+      // the configuration rather than passing the unclamped request on to the
+      // renderer — the two must agree about the same number.
+      return (configuration, isOpaque ? 1.0 : configuration.screenDim)
+
+    case .ambient:
+      let configuration = OverlayWindowManager.Configuration(
+        position: windowPosition(for: prefs.position),
+        width: prefs.width ?? 450,
+        height: height,
+        backgroundColor: .clear,
+        isTransparent: true,
+        isMoveable: prefs.moveable,
+        alwaysOnTop: true,
+        screenBlur: false,
+        dismissOnScreenTap: true,
+        animatePresentation: true,
+        takesKeyFocus: false
+      )
+      // No backdrop window at all, so the renderer owns the backdrop under its
+      // own text and must draw the local feathered scrim.
+      return (configuration, 0)
+    }
+  }
+
+  static func windowPosition(
+    for position: NotificationPosition
+  ) -> OverlayWindowManager.WindowPosition {
+    switch position {
+    case .center: return .center
+    case .topLeft: return .topLeft
+    case .topRight: return .topRight
+    case .bottomLeft: return .bottomLeft
+    case .bottomRight: return .bottomRight
+    }
+  }
 
   // MARK: - Generic Notification Methods
 

--- a/clients/macos-swift/VibeCare/VibeCare/Services/VibeNotifyConfiguration.swift
+++ b/clients/macos-swift/VibeCare/VibeCare/Services/VibeNotifyConfiguration.swift
@@ -184,11 +184,24 @@ enum VibeNotifyConfig {
       builder = builder.illustration(.symbol(defaultSystemIcon, pointSize: fallbackSymbolPointSize, color: nil))
     }
 
+    // A task-timer duration rides along on the action's parameters
+    // (`task_timer_seconds`, with optional `task_timer_unit_label` /
+    // `task_timer_completion_label`) — see `NotificationPreferences`. Absent
+    // or unparseable means `nil` here too, which is what keeps an action with
+    // no task timer rendering exactly as it did before this existed: no
+    // `.taskTimer(...)` call below, no ring.
+    let taskTimer: TaskTimer? = prefs.taskTimerSeconds.map { seconds in
+      TaskTimer(
+        duration: seconds,
+        unitLabel: prefs.taskTimerUnitLabel ?? "seconds",
+        completionLabel: prefs.taskTimerCompletionLabel ?? "Break complete"
+      )
+    }
+
     builder = builder
       .title(title)
       .message(message)
       .dismissOnScreenTap(true)
-      .autoDismiss(after: prefs.autoDismissAfter ?? quickDismissDelay)
       // The blur toggle is already the user's way of saying "take over my
       // screen for this", so it selects the alert mode rather than a lone
       // window knob — no new persisted key and no new control in the
@@ -198,6 +211,16 @@ enum VibeNotifyConfig {
       // appearance, which is exactly how a title landed invisible over a dark
       // terminal.
       //
+      // A task timer forces `.interrupt` regardless of `screenBlurEnabled`.
+      // `RichNotification.effectiveTaskTimer` returns `nil` in `.ambient` by
+      // design — a labelled ring reads as a task, and ambient alerts have
+      // none — so an action that set `task_timer_seconds` but left
+      // `screen_blur_enabled: false` would otherwise get no ring at all and
+      // no error to explain why. A duration the caller explicitly asked for
+      // is a stronger signal than a blur flag that may just be an
+      // unconsidered default, so this upgrades rather than silently drops
+      // the ring.
+      //
       // Setting `.mode(_:)` at all is what routes this funnel to the rich
       // renderer (see `NotificationBuilder.routesToRichRenderer`), which is
       // also why `.moveable`, `.alwaysOnTop` and `.screenBlur(_:intensity:)`
@@ -206,7 +229,38 @@ enum VibeNotifyConfig {
       // would read as though the preferences still reached the window.
       // `prefs.screenBlurIntensity` and `prefs.moveable` are consequently no
       // longer honoured for schedule alerts.
-      .mode(prefs.screenBlurEnabled ? .interrupt : .ambient)
+      .mode(taskTimer != nil || prefs.screenBlurEnabled ? .interrupt : .ambient)
+
+    if let taskTimer {
+      if !prefs.screenBlurEnabled {
+        logger.info(
+          "task_timer_seconds set without screen_blur_enabled; upgrading to .interrupt so the ring is visible",
+          metadata: ["duration": "\(taskTimer.duration)"]
+        )
+      }
+      builder = builder
+        .taskTimer(taskTimer)
+        .button(StandardNotification.Button(title: "Done", style: .primary, action: {}))
+        .button(StandardNotification.Button(title: "Skip", style: .secondary, action: {}))
+      // `auto_dismiss_after` is deliberately NOT forwarded here. A task timer
+      // and an auto-dismiss are sequential phases, not a race — the task
+      // runs first and alone, and the dismiss clock only arms once it hits
+      // zero, so honouring both would total `duration + delay` (e.g. the
+      // 20-20-20 action's 20s task + 25s dismiss = 45s on screen), which is
+      // very unlikely to be what an author who set a task duration meant.
+      // Leaving `AutoDismiss` unset lets the library's own short
+      // `completionHold` (1.5s) govern how long the completion/acknowledgement
+      // label holds before the window closes — an honest, brief beat instead
+      // of a silent 45-second alert.
+      if let autoDismissAfter = prefs.autoDismissAfter {
+        logger.debug(
+          "ignoring auto_dismiss_after because a task timer is present",
+          metadata: ["auto_dismiss_after": "\(autoDismissAfter)"]
+        )
+      }
+    } else {
+      builder = builder.autoDismiss(after: prefs.autoDismissAfter ?? quickDismissDelay)
+    }
 
     switch prefs.position {
     case .center:
@@ -227,8 +281,9 @@ enum VibeNotifyConfig {
     // The authored height is a floor — see `richAmbientHeight`. Unconditional
     // rather than branched on the mode because `.interrupt` ignores width and
     // height entirely (it takes the whole screen), so there is nothing for a
-    // branch to protect. A schedule alert carries no action buttons; its Done /
-    // Snooze row is a later task.
+    // branch to protect. `hasButtons` reserves the extra row height only for
+    // the Done/Skip pair a task timer adds — a plain schedule alert still has
+    // none.
     builder = builder.height(
       max(
         CGFloat(prefs.height ?? 0),
@@ -238,7 +293,7 @@ enum VibeNotifyConfig {
           // is still set, so that one case reserves the SVG's room for a smaller
           // symbol — over-reserving, which is the harmless direction.
           illustrationHeight: prefs.svgSize?.height ?? fallbackSymbolPointSize,
-          hasButtons: false
+          hasButtons: taskTimer != nil
         )
       )
     )

--- a/clients/macos-swift/VibeCare/VibeCare/Services/VibeNotifyConfiguration.swift
+++ b/clients/macos-swift/VibeCare/VibeCare/Services/VibeNotifyConfiguration.swift
@@ -5,7 +5,15 @@ import Logging
 
 // MARK: - BlurIntensity to VibeNotify Conversion
 extension BlurIntensity {
-    /// Convert VibeCare BlurIntensity to VibeNotify ScreenBlurIntensity
+    /// Convert VibeCare BlurIntensity to VibeNotify ScreenBlurIntensity.
+    ///
+    /// One of the three type-translation boundaries between VibeCare's own
+    /// vocabulary and VibeNotify's. Currently uncalled: both alert paths now
+    /// pick an `AlertMode`, and its factories own the backdrop — `.interrupt`
+    /// blurs heavily and dims to `Legibility.safeDim`, `.ambient` does not blur
+    /// at all. Kept because the boundary, not the call site, is the thing worth
+    /// preserving: it is where an intensity preference reconnects to a window
+    /// if the library ever exposes an intensity-taking mode.
     var vibeNotifyIntensity: ScreenBlurIntensity {
         switch self {
         case .light: return .light
@@ -36,10 +44,61 @@ enum VibeNotifyConfig {
   static let quickDismissDelay: TimeInterval = 3.0
   static let defaultBannerHeight: CGFloat = 120
   static let compactBannerHeight: CGFloat = 80
+  /// The SF Symbol size a schedule with no configured SVG falls back to. Large
+  /// enough to read as the alert's illustration rather than a decoration, and
+  /// scaled down by `Illustration.fitted(in:)` if the window is too small for
+  /// it.
+  static let fallbackSymbolPointSize: CGFloat = 56
 
   // MARK: - Logger
 
   private static let logger = Logger(label: "com.vibecare.vibe-notify-config")
+
+  // MARK: - Ambient Window Height
+
+  /// The window height an `.ambient` rich alert needs, which is not the height
+  /// the user — or a plugin appearance — authored.
+  ///
+  /// `.interrupt` needs no such calculation; it *is* the screen. `.ambient` is a
+  /// fixed-size window, and the rich renderer clips content that does not fit
+  /// rather than growing the window — deliberately, because an
+  /// `NSHostingView` free to publish its content's height resized an `.ambient`
+  /// window to 2289pt tall. Every authored height in this app predates that
+  /// renderer: they were chosen against one with no 28pt content padding, no
+  /// 26pt title and no half-height illustration cap. At the default 450x220 the
+  /// rich renderer clips its own illustration at the top and everything below
+  /// the message at the bottom. So an authored height is a floor, not a size.
+  ///
+  /// Erring high is close to free: the window is fully transparent and the
+  /// content is centred in it, so the only consequences are a larger
+  /// click-to-dismiss area and, at a corner position, content sitting a little
+  /// further from the corner. Erring low costs a button nobody can click.
+  ///
+  /// `min(illustrationHeight, chrome)` is the renderer's own rule rather than a
+  /// guess: `RichNotification.Illustration.fitted(in:)` scales an illustration
+  /// taller than half the window down to fit, so past `chrome` the window stops
+  /// growing with the picture and settles at twice the chrome.
+  ///
+  /// Calibrated by rendering `RichNotificationView` — with a live
+  /// `NotificationClock` in its environment, since the clock's own row costs
+  /// height — at scale 1, and finding the smallest height at which no ink
+  /// touches the frame edge. Over illustration heights of 56/150/200/300pt,
+  /// messages of one to five lines, and widths of 300/350/450pt, the worst cases
+  /// were 248pt of chrome without a button row and 286pt with one. Both worst
+  /// cases are a five-line message, which is not hypothetical: it is what the
+  /// customization sheet's preview substitutes when no message is set.
+  static func richAmbientHeight(illustrationHeight: CGFloat, hasButtons: Bool) -> CGFloat {
+    let chrome = hasButtons ? richChromeWithButtons : richChrome
+    return chrome + min(illustrationHeight, chrome)
+  }
+
+  /// Room for everything the rich renderer draws that is not the illustration:
+  /// 28pt of padding top and bottom, a 26pt title, the message, 22pt between
+  /// each element, and the dismiss clock's own row. Measured worst case 248 (see
+  /// above); the margin is for a message longer than any measured.
+  private static let richChrome: CGFloat = 264
+  /// `richChrome` with a row of action buttons — measured worst case 286.
+  private static let richChromeWithButtons: CGFloat = 304
 
   // MARK: - Schedule Notification
 
@@ -103,32 +162,51 @@ enum VibeNotifyConfig {
 
     var builder = VibeNotify.builder()
 
-    // Icon: SVG (url/file) if configured, else the caller's default system icon.
+    // Illustration: SVG (url/file) if configured, else the caller's default
+    // system icon as an SF Symbol. Deliberately `.illustration(.symbol(...))`
+    // rather than `.icon(.system(...))`: the latter is a
+    // `StandardNotification.IconType`, which the rich renderer's routing does
+    // not recognise as an illustration at all, so the no-SVG case — what every
+    // unconfigured schedule gets — would render without a picture. A nil
+    // `color` means "the title colour", i.e. whatever is legible over the
+    // scrim the renderer drew.
     if let svgPath = prefs.resolvedSVGPath, let svgSize = prefs.svgSize {
       if svgPath.hasPrefix("http://") || svgPath.hasPrefix("https://") {
         if let url = URL(string: svgPath) {
           builder = builder.svgURL(url, size: svgSize)
         } else {
-          builder = builder.icon(.system(defaultSystemIcon))
+          builder = builder.illustration(.symbol(defaultSystemIcon, pointSize: fallbackSymbolPointSize, color: nil))
         }
       } else {
         builder = builder.svg(svgPath, size: svgSize)
       }
     } else {
-      builder = builder.icon(.system(defaultSystemIcon))
+      builder = builder.illustration(.symbol(defaultSystemIcon, pointSize: fallbackSymbolPointSize, color: nil))
     }
 
     builder = builder
       .title(title)
       .message(message)
-      .moveable(prefs.moveable)
-      .alwaysOnTop(true)
       .dismissOnScreenTap(true)
       .autoDismiss(after: prefs.autoDismissAfter ?? quickDismissDelay)
-
-    if prefs.screenBlurEnabled {
-      builder = builder.screenBlur(true, intensity: prefs.screenBlurIntensity.vibeNotifyIntensity)
-    }
+      // The blur toggle is already the user's way of saying "take over my
+      // screen for this", so it selects the alert mode rather than a lone
+      // window knob — no new persisted key and no new control in the
+      // customization UI. `.interrupt` dims the whole screen to
+      // `Legibility.safeDim` and picks text colours against that dim; the old
+      // code pinned a light blur at 0.1 and chose text from the system
+      // appearance, which is exactly how a title landed invisible over a dark
+      // terminal.
+      //
+      // Setting `.mode(_:)` at all is what routes this funnel to the rich
+      // renderer (see `NotificationBuilder.routesToRichRenderer`), which is
+      // also why `.moveable`, `.alwaysOnTop` and `.screenBlur(_:intensity:)`
+      // are gone from this chain: `AlertMode`'s factories own the whole
+      // window `Configuration` now, and leaving inert builder calls here
+      // would read as though the preferences still reached the window.
+      // `prefs.screenBlurIntensity` and `prefs.moveable` are consequently no
+      // longer honoured for schedule alerts.
+      .mode(prefs.screenBlurEnabled ? .interrupt : .ambient)
 
     switch prefs.position {
     case .center:
@@ -146,9 +224,24 @@ enum VibeNotifyConfig {
     if let width = prefs.width {
       builder = builder.width(CGFloat(width))
     }
-    if let height = prefs.height {
-      builder = builder.height(CGFloat(height))
-    }
+    // The authored height is a floor — see `richAmbientHeight`. Unconditional
+    // rather than branched on the mode because `.interrupt` ignores width and
+    // height entirely (it takes the whole screen), so there is nothing for a
+    // branch to protect. A schedule alert carries no action buttons; its Done /
+    // Snooze row is a later task.
+    builder = builder.height(
+      max(
+        CGFloat(prefs.height ?? 0),
+        richAmbientHeight(
+          // The height of the picture as the renderer will be asked to draw it.
+          // The invalid-URL branch above falls back to a symbol while `svgSize`
+          // is still set, so that one case reserves the SVG's room for a smaller
+          // symbol — over-reserving, which is the harmless direction.
+          illustrationHeight: prefs.svgSize?.height ?? fallbackSymbolPointSize,
+          hasButtons: false
+        )
+      )
+    )
 
     return builder.show()
   }

--- a/clients/macos-swift/VibeCare/VibeCare/ViewModels/AppState.swift
+++ b/clients/macos-swift/VibeCare/VibeCare/ViewModels/AppState.swift
@@ -24,6 +24,44 @@ public class AppState: ObservableObject {
     private init() {
         loadCachedProfile()
         setupEventHandlers()
+        observeProfileForGlobalSettings()
+    }
+
+    // MARK: - Global Notification Settings
+
+    /// Keeps `GlobalNotificationSettings`' local mirror in step with whichever
+    /// profile is current.
+    ///
+    /// A sink on `$currentProfile` rather than a call at each assignment site:
+    /// the profile is set in four places (restore-from-cache, `selectProfile`,
+    /// and twice in `updateProfile`'s local-first/server-response pair), and a
+    /// hydration that only ran at three of them would be a bug nobody could see
+    /// until an alert rendered with the wrong look.
+    private func observeProfileForGlobalSettings() {
+        $currentProfile
+            .compactMap { $0 }
+            .sink { profile in
+                GlobalNotificationSettings.hydrate(from: profile.preferences)
+            }
+            .store(in: &cancellables)
+    }
+
+    /// Persists global notification appearance: the local mirror first (so the
+    /// very next alert uses it even if the backend is unreachable), then the
+    /// profile, which is the durable, cross-device copy.
+    ///
+    /// Goes through `updateProfile` rather than talking to `ProfileService`
+    /// directly so it inherits the same local-first-then-sync behaviour every
+    /// other profile edit already has.
+    func saveGlobalNotificationSettings(_ settings: GlobalNotificationSettings) {
+        settings.persistLocally()
+
+        guard var profile = currentProfile else {
+            logger.info("No current profile; global notification settings saved locally only")
+            return
+        }
+        profile.preferences = settings.merged(into: profile.preferences)
+        updateProfile(profile)
     }
 
     // MARK: - Public Methods

--- a/clients/macos-swift/VibeCare/VibeCare/ViewModels/NotificationActionViewModel.swift
+++ b/clients/macos-swift/VibeCare/VibeCare/ViewModels/NotificationActionViewModel.swift
@@ -8,12 +8,43 @@ import Logging
 final class NotificationActionViewModel {
     var preferences: NotificationPreferences
     var parameters: [String: String]
+    /// Whether this action pins its own appearance instead of inheriting the
+    /// global notification settings. See `ScheduleActionCard.overridesAppearance`
+    /// for why this is derived from the parameters rather than stored beside
+    /// them.
+    var overridesAppearance: Bool
 
     private let logger = Logger(label: "com.vibecare.notification-action-vm")
 
-    init(preferences: NotificationPreferences, parameters: [String: String]) {
+    init(
+        preferences: NotificationPreferences,
+        parameters: [String: String],
+        overridesAppearance: Bool? = nil
+    ) {
         self.preferences = preferences
         self.parameters = parameters
+        self.overridesAppearance =
+            overridesAppearance ?? GlobalNotificationSettings.overridesAppearance(parameters)
+    }
+
+    /// Turns the per-action override on or off.
+    ///
+    /// Switching it **off** re-seeds the appearance fields from the global
+    /// settings, so the (now read-only-in-effect) controls stop showing values
+    /// that no longer apply. Content — icon, title, message, break duration —
+    /// is untouched either way; it has no global counterpart.
+    func setOverridesAppearance(_ overrides: Bool) {
+        overridesAppearance = overrides
+        guard !overrides else { return }
+
+        let global = GlobalNotificationSettings.current
+        preferences.position = global.position
+        preferences.width = global.width
+        preferences.height = global.height
+        preferences.moveable = global.moveable
+        preferences.autoDismissAfter = global.autoDismissAfter
+        preferences.screenBlurEnabled = global.screenBlurEnabled
+        preferences.screenBlurIntensity = global.screenBlurIntensity
     }
 
     // MARK: - Convenience Update Methods
@@ -62,14 +93,17 @@ final class NotificationActionViewModel {
         preferences.svgHeight = height
     }
 
-    /// Reset preferences to default
+    /// Reset preferences to the user's global notification settings
     func resetToDefault() {
-        preferences = .default
+        preferences = GlobalNotificationSettings.current.basePreferences()
+        overridesAppearance = false
     }
 
-    /// Apply a preset configuration
+    /// Apply a preset configuration. A preset is entirely appearance, so
+    /// picking one *is* the decision to override the global settings.
     func applyPreset(_ preset: NotificationPreferences) {
-        preferences = preset
+        preferences = preset.copy()
+        overridesAppearance = true
     }
 
     // MARK: - Serialization
@@ -112,6 +146,24 @@ final class NotificationActionViewModel {
             parameters["body"] = ""
         }
 
+        // Serialize the break countdown's duration. Content, not appearance:
+        // whether an action runs a break is what the action *is*, and only its
+        // wording comes from the global settings.
+        if let taskTimerSeconds = preferences.taskTimerSeconds {
+            parameters["task_timer_seconds"] = String(taskTimerSeconds)
+        } else {
+            parameters.removeValue(forKey: "task_timer_seconds")
+        }
+
+        // Appearance — written only when this action overrides the global
+        // settings, and actively cleared when it does not. See
+        // `ScheduleActionCard.serializeNotificationPreferences` for why the
+        // clearing half matters.
+        guard overridesAppearance else {
+            parameters = GlobalNotificationSettings.clearingAppearance(parameters)
+            return
+        }
+
         // Serialize position and dimensions
         parameters["position"] = preferences.position.rawValue
         if let width = preferences.width {
@@ -127,6 +179,7 @@ final class NotificationActionViewModel {
             parameters["auto_dismiss_after"] = String(autoDismiss)
         }
         parameters["screen_blur_enabled"] = String(preferences.screenBlurEnabled)
+        parameters["screen_blur_intensity"] = preferences.screenBlurIntensity.rawValue
 
         logger.debug("🔍 serializeToParameters - END", metadata: [
             "svg_path": "\(parameters["svg_path"] ?? "nil")",
@@ -146,7 +199,10 @@ final class NotificationActionViewModel {
            let decoded = try? JSONDecoder().decode(NotificationPreferences.self, from: data) {
             preferences = decoded
         } else {
-            preferences = .default
+            // Global settings as defaults, per-action keys on top — the same
+            // resolution the delivery path performs.
+            preferences = GlobalNotificationSettings.current.resolving(
+                actionParameters: action.parameters)
         }
 
         return NotificationActionViewModel(

--- a/clients/macos-swift/VibeCare/VibeCare/Views/Plugins/PluginAlertOverlay.swift
+++ b/clients/macos-swift/VibeCare/VibeCare/Views/Plugins/PluginAlertOverlay.swift
@@ -2,153 +2,28 @@ import AppKit
 import SwiftUI
 import VibeNotify
 
-/// The shell's own rendering of a plugin alert that carried an appearance
-/// (ruling U2).
-///
-/// ## Why this view exists at all
-///
-/// VibeNotify 0.0.5 has two built-in renderers and neither can draw an
-/// illustration and buttons at the same time:
-///
-/// * `SVGNotificationView` draws a full-size SVG, and `SVGNotification` has
-///   no `buttons` property — the builder's buttons are dropped on the way in.
-/// * `StandardNotificationView` draws buttons, but renders
-///   `IconType.svg`/`.url` as `EmptyView()` and pins `IconType.image` to a
-///   hardcoded 48x48 frame.
-///
-/// The package's third path — a caller-supplied SwiftUI view rendered in the
-/// same overlay window machinery — has neither limitation, so the layout
-/// lives here instead. It is deliberately modelled on `SVGNotificationView`
-/// (the "old and nice" design): illustration at full size, no card chrome,
-/// floating over the blurred screen, adaptive text with a glow in dark mode.
-/// The button row is the one addition.
-///
-/// ## Why it is not plugin-specific
-///
-/// Nothing here names a plugin or knows what any alert means. It renders the
-/// shell's own appearance vocabulary (`PluginAlertPresentation`), which any
-/// plugin may send. That is the rule that lets a plugin ship a styled alert
-/// without a client release.
-struct PluginAlertOverlayView: View {
-    let icon: NSImage?
-    let iconSize: CGSize
-    let title: String
-    let message: String
-    let actions: [NotificationAction]
-    let onDismiss: () -> Void
-
-    @Environment(\.colorScheme) private var colorScheme
-
-    @State private var scale: CGFloat = 0.8
-    @State private var opacity: Double = 0.0
-
-    /// Follows the system theme, exactly as `SVGNotificationView` does: the
-    /// alert floats over a blurred desktop with no background of its own, so
-    /// the text needs a glow to stay legible against whatever is behind it.
-    private var useLightText: Bool { colorScheme == .dark }
-
-    var body: some View {
-        VStack(spacing: 20) {
-            if let icon {
-                Image(nsImage: icon)
-                    .resizable()
-                    .scaledToFit()
-                    .frame(width: iconSize.width, height: iconSize.height)
-                    .shadow(color: useLightText ? .white.opacity(0.5) : .black.opacity(0.5), radius: 15)
-            }
-
-            if !title.isEmpty {
-                Text(title)
-                    .font(.title2)
-                    .fontWeight(.semibold)
-                    .foregroundColor(useLightText ? .white : .primary)
-                    .shadow(color: useLightText ? .white.opacity(0.3) : .clear, radius: 4)
-                    .multilineTextAlignment(.center)
-            }
-
-            if !message.isEmpty {
-                Text(message)
-                    .font(.body)
-                    .foregroundColor(useLightText ? .white.opacity(0.9) : .secondary)
-                    .shadow(color: useLightText ? .white.opacity(0.2) : .clear, radius: 3)
-                    .multilineTextAlignment(.center)
-            }
-
-            if !actions.isEmpty {
-                HStack(spacing: 12) {
-                    ForEach(Array(actions.enumerated()), id: \.offset) { _, action in
-                        SwiftUI.Button {
-                            // Run the action, then take the alert down. The
-                            // action itself is a fire-and-forget HTTP call
-                            // (see PluginShellService.performAction), so
-                            // waiting for it would leave the alert on screen
-                            // for a round trip with no feedback.
-                            action.handler()
-                            onDismiss()
-                        } label: {
-                            Text(action.label)
-                                .fontWeight(.medium)
-                                .padding(.horizontal, 18)
-                                .padding(.vertical, 9)
-                        }
-                        .buttonStyle(PluginAlertButtonStyle())
-                    }
-                }
-                .padding(.top, 4)
-            }
-        }
-        .padding(24)
-        // The whole card is a hit target for dismissal EXCEPT the buttons,
-        // which take their taps first. Without `contentShape` the transparent
-        // padding around the content would not respond at all.
-        .contentShape(Rectangle())
-        .onTapGesture { onDismiss() }
-        .onAppear {
-            withAnimation(.spring(response: 0.6, dampingFraction: 0.7)) {
-                scale = 1.0
-                opacity = 1.0
-            }
-        }
-        .scaleEffect(scale)
-        .opacity(opacity)
-    }
-}
-
-/// A button legible against a blurred desktop. VibeNotify's own
-/// `SecondaryButtonStyle` is internal to that package, and a plain
-/// `.bordered` button disappears against a light-blurred background, so the
-/// style is owned here.
-private struct PluginAlertButtonStyle: ButtonStyle {
-    func makeBody(configuration: Configuration) -> some View {
-        configuration.label
-            .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 8))
-            .overlay(
-                RoundedRectangle(cornerRadius: 8)
-                    .strokeBorder(Color.primary.opacity(0.15), lineWidth: 1)
-            )
-            .foregroundColor(.primary)
-            .opacity(configuration.isPressed ? 0.7 : 1.0)
-    }
-}
-
 // MARK: - Presenter
 
-/// Shows `PluginAlertOverlayView` in VibeNotify's overlay window.
+/// Presents a plugin alert that carried an appearance (ruling U2) through
+/// VibeNotify's rich renderer.
 ///
-/// This goes through `OverlayWindowManager.show(id:configuration:content:)`
-/// rather than `VibeNotify.showCustom(...)`. They are the same mechanism —
-/// `showCustom` is a four-argument wrapper around this exact call — but
-/// `showCustom` hardcodes the rest of the `Configuration`, and the three
-/// things it drops are the three this alert needs most: `screenBlur` (with
-/// its separate full-screen blur window), `position`, and `width`/`height`.
-/// Rebuilding full-screen blur inside the view is not equivalent: a material
-/// in the view's own background blurs only what is behind the 450x220 window,
-/// whereas the old design dimmed the entire screen. Using the underlying
-/// public method keeps that behaviour identical to the old alert instead of
-/// approximating it.
+/// A client-owned SwiftUI view used to live here, because neither built-in
+/// renderer could draw an illustration and buttons at the same time. The rich
+/// renderer draws both, so the view is gone, and with it the hand-written
+/// fifteen-argument window `Configuration`, the hand-rolled button style and the
+/// `asyncAfter` that stood in for a countdown. Deleting the view is also how
+/// this path *inherits* the contrast-correct text treatment rather than needing
+/// it ported: the old view picked its colours from the system appearance alone —
+/// a white glow under white text, a `.clear` shadow in light mode — which is the
+/// bug the rich renderer exists to fix.
 ///
-/// Auto-dismiss IS ours to schedule: the built-in renderers each run their
-/// own timer, and a caller-supplied view gets none.
+/// `.ambient`, not `.interrupt`, even when the appearance asked for blur: a
+/// plugin alert is a positioned window whose geometry plugins author against,
+/// and `.interrupt` deliberately ignores position and size in order to own the
+/// whole screen. Legibility over an arbitrary desktop comes from the renderer's
+/// local feathered scrim instead of a full-screen dim, which is what `.ambient`
+/// is for. The consequence is that `PluginAlertPresentation.blurIntensity` no
+/// longer reaches a window — `.ambient` builds no blur window at all.
 @MainActor
 enum PluginAlertPresenter {
     /// Presents the alert and returns its overlay id, or nil if notification
@@ -166,50 +41,57 @@ enum PluginAlertPresenter {
             return nil
         }
 
-        let id = UUID()
-        let view = PluginAlertOverlayView(
-            icon: icon,
-            iconSize: presentation.iconSize,
+        let notification = RichNotification(
+            // `.image`, never a URL. The icon arrives already fetched because
+            // fetching goes through core's reverse proxy with a `vc_session`
+            // cookie (`PluginShellService.resolveIcon`); handing VibeNotify a
+            // URL would re-fetch it unauthenticated and fail.
+            illustration: icon.map { .image($0, size: presentation.iconSize) },
             title: title,
             message: message,
-            actions: actions,
-            onDismiss: { OverlayWindowManager.shared.dismiss(id: id) }
+            buttons: actions.map { action in
+                // `.secondary` so the library cancels the dismiss clock and then
+                // takes the window down after running the handler. The handler
+                // is a fire-and-forget HTTP call
+                // (`PluginShellService.performAction`), so waiting on it would
+                // leave the alert up for a round trip with no feedback.
+                StandardNotification.Button(
+                    title: action.label, style: .secondary, action: action.handler)
+            },
+            // The clock owns the alert's lifetime now, which the `asyncAfter`
+            // this replaces never could: an early dismissal cancels it instead
+            // of leaving a timer to fire into a window that is already gone.
+            // `.none` because the alert this reproduces showed no countdown.
+            autoDismiss: .init(delay: presentation.autoDismissAfter, indicator: .none),
+            mode: .ambient
         )
 
-        let height = fittingHeight(for: view, width: presentation.width, atLeast: presentation.minHeight)
-
-        let configuration = OverlayWindowManager.Configuration(
-            // Position + explicit width/height override the presentation
-            // mode entirely (see OverlayWindowManager.createWindow), so this
-            // is only a starting rect.
-            presentationMode: .fullScreen,
-            position: windowPosition(for: presentation.position),
+        // The appearance's height is a floor, and in the rich renderer it is a
+        // floor well below what the content occupies — `richAmbientHeight`
+        // carries the measurements and the reasoning, and lives next to the
+        // schedule path because both feed the same renderer and the metrics
+        // being mirrored are one renderer's.
+        let height = fittingHeight(
+            for: RichNotificationView(notification: notification, onDismiss: {}),
             width: presentation.width,
-            height: height,
-            windowLevel: .floating,
-            backgroundColor: .clear,
-            isTransparent: true,
-            ignoresMouseEvents: false,
-            isMoveable: presentation.moveable,
-            alwaysOnTop: true,
-            // No window material: the design floats over the blurred screen
-            // with no card behind it, same as the alert this replaces.
-            transparent: false,
-            screenBlur: presentation.blurIntensity != nil,
-            screenBlurIntensity: presentation.blurIntensity?.vibeNotifyIntensity,
-            dismissOnScreenTap: true,
-            animatePresentation: true
+            atLeast: max(
+                presentation.minHeight,
+                VibeNotifyConfig.richAmbientHeight(
+                    illustrationHeight: icon == nil ? 0 : presentation.iconSize.height,
+                    hasButtons: !actions.isEmpty
+                )
+            )
         )
 
-        OverlayWindowManager.shared.show(id: id, configuration: configuration) { view }
-
-        // Dismissing an already-dismissed id is a no-op inside
-        // OverlayWindowManager (it looks the window up first), so a button
-        // press that beats the timer needs no cancellation here.
-        DispatchQueue.main.asyncAfter(deadline: .now() + presentation.autoDismissAfter) {
-            OverlayWindowManager.shared.dismiss(id: id)
-        }
-        return id
+        return VibeNotify.shared.showRich(
+            notification,
+            configuration: .ambient(
+                position: windowPosition(for: presentation.position),
+                width: presentation.width,
+                height: height,
+                dismissOnScreenTap: true
+            )
+        )
     }
 
     /// The height the content actually needs at this width, floored at the
@@ -221,6 +103,13 @@ enum PluginAlertPresenter {
     /// merely ugly but unclickable — and the button in question is "Turn
     /// off". `fittingSize` can report zero for content SwiftUI cannot size
     /// eagerly, so a zero measurement falls back to the configured height.
+    ///
+    /// `RichNotificationView` is one such view, deliberately: its
+    /// `GeometryReader` exists precisely so the hosted content publishes no
+    /// height of its own and cannot resize the window it was given. Measured
+    /// through this probe it reports 10pt, so today the floor always wins and
+    /// `VibeNotifyConfig.richAmbientHeight` is what decides the window. This
+    /// stays the way in for a renderer that ever does report a real size.
     private static func fittingHeight(
         for view: some View, width: CGFloat, atLeast minimum: CGFloat
     ) -> CGFloat {

--- a/clients/macos-swift/VibeCare/VibeCare/Views/Schedules/ActionCardView.swift
+++ b/clients/macos-swift/VibeCare/VibeCare/Views/Schedules/ActionCardView.swift
@@ -8,12 +8,23 @@ struct ScheduleActionCard: Identifiable, Equatable {
     let id: String
     var type: ActionType
     var parameters: [String: String]
-    var notificationPreferences: NotificationPreferences = .default // For notification actions
+    var notificationPreferences: NotificationPreferences = GlobalNotificationSettings.current.basePreferences() // For notification actions
+    /// Whether this action overrides the global notification appearance.
+    ///
+    /// Not persisted as a flag of its own: the *presence* of the appearance
+    /// keys in `parameters` is the persisted state, and this is derived from
+    /// them on load (`GlobalNotificationSettings.overridesAppearance`) and
+    /// written back to them on save. That way an action authored by the CLI or
+    /// MCP with only a `position` reads correctly here without ever having
+    /// passed through this app, and there is no second copy of the truth to
+    /// drift.
+    var overridesAppearance: Bool = false
 
     static func == (lhs: ScheduleActionCard, rhs: ScheduleActionCard) -> Bool {
         return lhs.id == rhs.id &&
                lhs.type == rhs.type &&
                lhs.parameters == rhs.parameters &&
+               lhs.overridesAppearance == rhs.overridesAppearance &&
                lhs.notificationPreferences == rhs.notificationPreferences
     }
 
@@ -33,16 +44,19 @@ struct ScheduleActionCard: Identifiable, Equatable {
                     "title": "",
                     "body": ""
                 ]
-                self.notificationPreferences = .default
+                // A brand-new action inherits the global look — no appearance
+                // keys written, so `overridesAppearance` stays false and the
+                // controls it seeds show what the alert will actually look like.
+                self.notificationPreferences = GlobalNotificationSettings.current.basePreferences()
+                self.overridesAppearance = false
             } else {
                 // Loading existing action - deserialize from parameters
                 print("DEBUG [ScheduleActionCard.init]: Loading existing notification action from parameters")
                 self.parameters = parameters
-                let deserialized = Self.deserializeNotificationPreferences(from: parameters)
-                print("DEBUG [ScheduleActionCard.init]: Deserialized notification prefs: \(deserialized != nil ? "present" : "nil")")
-                self.notificationPreferences = deserialized ?? .default
+                self.notificationPreferences = Self.deserializeNotificationPreferences(from: parameters)
+                self.overridesAppearance = GlobalNotificationSettings.overridesAppearance(parameters)
 
-                print("DEBUG [ScheduleActionCard.init]: Final prefs: title=\(notificationPreferences.title ?? "nil"), position=\(notificationPreferences.position)")
+                print("DEBUG [ScheduleActionCard.init]: Final prefs: title=\(notificationPreferences.title ?? "nil"), position=\(notificationPreferences.position), overridesAppearance=\(overridesAppearance)")
             }
         } else {
             // Seed missing values from each parameter's defaultValue (e.g. system
@@ -58,7 +72,11 @@ struct ScheduleActionCard: Identifiable, Equatable {
 
         // Serialize notification preferences into parameters for notification actions
         if type == .notification {
-            actionParams = Self.serializeNotificationPreferences(notificationPreferences, into: actionParams)
+            actionParams = Self.serializeNotificationPreferences(
+                notificationPreferences,
+                into: actionParams,
+                overridesAppearance: overridesAppearance
+            )
 
             // Apply defaults for empty title/body
             if actionParams["title"]?.isEmpty ?? true {
@@ -140,7 +158,20 @@ struct ScheduleActionCard: Identifiable, Equatable {
 
     // MARK: - Notification Preferences Serialization
 
-    private static func serializeNotificationPreferences(_ prefs: NotificationPreferences, into params: [String: String]) -> [String: String] {
+    /// Writes an action's *content* always, and its *appearance* only when the
+    /// action actually overrides the global settings.
+    ///
+    /// The `overridesAppearance == false` branch **removes** the appearance
+    /// keys rather than leaving whatever was there. That is what makes the
+    /// inheritance real: writing `position`/`moveable`/`screen_blur_enabled`
+    /// unconditionally — as this used to — meant every action ever opened in
+    /// the editor pinned its own appearance forever, and a later change to the
+    /// global settings would reach none of them.
+    private static func serializeNotificationPreferences(
+        _ prefs: NotificationPreferences,
+        into params: [String: String],
+        overridesAppearance: Bool
+    ) -> [String: String] {
         var result = params  // Start with existing params to preserve title/body from UI
 
         // Serialize SVG path (works for both bundled URLs and custom file paths)
@@ -174,19 +205,23 @@ struct ScheduleActionCard: Identifiable, Equatable {
             result["body"] = ""
         }
 
-        result["position"] = prefs.position.rawValue
-        if let width = prefs.width {
-            result["width"] = String(Double(width))
+        if overridesAppearance {
+            result["position"] = prefs.position.rawValue
+            if let width = prefs.width {
+                result["width"] = String(Double(width))
+            }
+            if let height = prefs.height {
+                result["height"] = String(Double(height))
+            }
+            result["moveable"] = String(prefs.moveable)
+            if let autoDismiss = prefs.autoDismissAfter {
+                result["auto_dismiss_after"] = String(autoDismiss)
+            }
+            result["screen_blur_enabled"] = String(prefs.screenBlurEnabled)
+            result["screen_blur_intensity"] = prefs.screenBlurIntensity.rawValue
+        } else {
+            result = GlobalNotificationSettings.clearingAppearance(result)
         }
-        if let height = prefs.height {
-            result["height"] = String(Double(height))
-        }
-        result["moveable"] = String(prefs.moveable)
-        if let autoDismiss = prefs.autoDismissAfter {
-            result["auto_dismiss_after"] = String(autoDismiss)
-        }
-        result["screen_blur_enabled"] = String(prefs.screenBlurEnabled)
-        result["screen_blur_intensity"] = prefs.screenBlurIntensity.rawValue
 
         if let taskTimerSeconds = prefs.taskTimerSeconds {
             result["task_timer_seconds"] = String(taskTimerSeconds)
@@ -203,45 +238,14 @@ struct ScheduleActionCard: Identifiable, Equatable {
         return result
     }
 
-    private static func deserializeNotificationPreferences(from params: [String: String]) -> NotificationPreferences? {
-        // Create notification preferences from parameters
-        // Only read svg_path (contains full URL for both bundled and custom icons)
-        let svgPath = params["svg_path"]
-        let svgWidth = params["svg_width"].flatMap { Double($0) }.map { CGFloat($0) }
-        let svgHeight = params["svg_height"].flatMap { Double($0) }.map { CGFloat($0) }
-        let title = params["title"]
-        let message = params["body"]
-        let position = params["position"].flatMap { NotificationPosition(rawValue: $0) } ?? .center
-        let width = params["width"].flatMap { Double($0) }.map { CGFloat($0) }
-        let height = params["height"].flatMap { Double($0) }.map { CGFloat($0) }
-        let moveable = params["moveable"].flatMap { Bool($0) } ?? true
-        let autoDismissAfter = params["auto_dismiss_after"].flatMap { Double($0) }
-        let screenBlurEnabled = params["screen_blur_enabled"].flatMap { Bool($0) } ?? false
-        let screenBlurIntensity = params["screen_blur_intensity"].flatMap { BlurIntensity(rawValue: $0) } ?? .medium
-        // Absent or unparseable means no task timer — today's behaviour,
-        // unchanged (see `NotificationPreferences.taskTimerSeconds`).
-        let taskTimerSeconds = params["task_timer_seconds"].flatMap { Double($0) }
-        let taskTimerUnitLabel = params["task_timer_unit_label"]
-        let taskTimerCompletionLabel = params["task_timer_completion_label"]
-
-        return NotificationPreferences(
-            bundledIconId: nil, // Always nil now - IDs converted to URLs
-            svgPath: svgPath,
-            svgWidth: svgWidth,
-            svgHeight: svgHeight,
-            title: title,
-            message: message,
-            position: position,
-            width: width,
-            height: height,
-            moveable: moveable,
-            autoDismissAfter: autoDismissAfter,
-            screenBlurEnabled: screenBlurEnabled,
-            screenBlurIntensity: screenBlurIntensity,
-            taskTimerSeconds: taskTimerSeconds,
-            taskTimerUnitLabel: taskTimerUnitLabel,
-            taskTimerCompletionLabel: taskTimerCompletionLabel
-        )
+    /// The same resolution the delivery path performs
+    /// (`NotificationManager.deserializeNotificationPreferences`), through the
+    /// same function: global settings as defaults, per-action keys winning
+    /// where present. Sharing it is what keeps the editor's controls showing
+    /// the values the alert will actually be rendered with, including for the
+    /// keys this action does not override.
+    private static func deserializeNotificationPreferences(from params: [String: String]) -> NotificationPreferences {
+        GlobalNotificationSettings.current.resolving(actionParameters: params)
     }
 }
 
@@ -401,6 +405,9 @@ struct NotificationActionParametersView: View {
     @State private var showingFilePicker = false
     @State private var showingIconPicker = false
     @State private var previewNotification = false
+    /// Closed by default: the appearance controls it holds are the ones the
+    /// global settings now answer for.
+    @State private var advancedExpanded = false
     @ObservedObject private var iconManager = SVGIconManager.shared
 
     // SVG icon preview state
@@ -414,23 +421,115 @@ struct NotificationActionParametersView: View {
         @Bindable var vm = viewModel
 
         VStack(alignment: .leading, spacing: 16) {
-            // Quick Presets
-            presetSection
-
-            // SVG Icon Section
+            // Content: what this notification says. Always visible — it is the
+            // only part of an action that has no global counterpart.
             svgIconSection
 
-            // Message Customization
             messageCustomizationSection
 
-            // Position Section
-            positionSection
+            breakCountdownSection
 
-            // Size Controls
-            sizeSection
+            // Appearance: how it looks. Collapsed by default, because the
+            // answer for almost every action is "the same as everything else",
+            // and that answer now lives in Settings › Notifications.
+            appearanceDisclosure
+        }
+    }
 
-            // Behavior Options
-            behaviorSection
+    // MARK: - Appearance Disclosure
+
+    /// The demoted per-action appearance controls.
+    ///
+    /// Closed by default and headed by a line that says, in as many words,
+    /// where the appearance is coming from — an action that overrides nothing
+    /// should not make the user open a disclosure to find that out.
+    private var appearanceDisclosure: some View {
+        @Bindable var vm = viewModel
+
+        return DisclosureGroup(isExpanded: $advancedExpanded) {
+            VStack(alignment: .leading, spacing: 16) {
+                Toggle(isOn: Binding(
+                    get: { vm.overridesAppearance },
+                    set: { viewModel.setOverridesAppearance($0) }
+                )) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Override global appearance for this action")
+                            .font(.caption)
+                        Text("Turn off to follow Settings › Notifications.")
+                            .font(.caption2)
+                            .foregroundColor(.secondary)
+                    }
+                }
+                .toggleStyle(.switch)
+
+                Group {
+                    presetSection
+                    positionSection
+                    sizeSection
+                    behaviorSection
+                }
+                .disabled(!vm.overridesAppearance)
+                .opacity(vm.overridesAppearance ? 1 : 0.5)
+            }
+            .padding(.top, 8)
+        } label: {
+            HStack(spacing: 6) {
+                Text("Advanced")
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+                Text(inheritanceSummary)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+        }
+    }
+
+    private var inheritanceSummary: String {
+        viewModel.overridesAppearance
+            ? "Custom appearance for this action"
+            : "Using global notification settings"
+    }
+
+    // MARK: - Break Countdown Section
+
+    /// The break duration, which is content rather than appearance: whether an
+    /// action runs a break is what the action *is*. Its wording — the unit and
+    /// completion labels — comes from the global settings.
+    private var breakCountdownSection: some View {
+        @Bindable var vm = viewModel
+
+        return VStack(alignment: .leading, spacing: 8) {
+            Text("Break Countdown")
+                .font(.subheadline)
+                .fontWeight(.medium)
+
+            Toggle("Show a break countdown", isOn: Binding(
+                get: { vm.preferences.taskTimerSeconds != nil },
+                set: { vm.preferences.taskTimerSeconds = $0 ? 20 : nil }
+            ))
+            .toggleStyle(.switch)
+            .font(.caption)
+
+            if let seconds = vm.preferences.taskTimerSeconds {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Duration: \(Int(seconds))s")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+
+                    Slider(
+                        value: Binding(
+                            get: { seconds },
+                            set: { vm.preferences.taskTimerSeconds = $0 }
+                        ),
+                        in: 5...300,
+                        step: 5
+                    )
+                }
+
+                Text("Shown as a full-screen countdown labelled “\(GlobalNotificationSettings.current.breakUnitLabel)”, ending in “\(GlobalNotificationSettings.current.breakCompletionLabel)”. Change the wording in Settings › Notifications.")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
         }
     }
 

--- a/clients/macos-swift/VibeCare/VibeCare/Views/Schedules/ActionCardView.swift
+++ b/clients/macos-swift/VibeCare/VibeCare/Views/Schedules/ActionCardView.swift
@@ -188,6 +188,18 @@ struct ScheduleActionCard: Identifiable, Equatable {
         result["screen_blur_enabled"] = String(prefs.screenBlurEnabled)
         result["screen_blur_intensity"] = prefs.screenBlurIntensity.rawValue
 
+        if let taskTimerSeconds = prefs.taskTimerSeconds {
+            result["task_timer_seconds"] = String(taskTimerSeconds)
+        } else {
+            result.removeValue(forKey: "task_timer_seconds")
+        }
+        if let unitLabel = prefs.taskTimerUnitLabel, !unitLabel.isEmpty {
+            result["task_timer_unit_label"] = unitLabel
+        }
+        if let completionLabel = prefs.taskTimerCompletionLabel, !completionLabel.isEmpty {
+            result["task_timer_completion_label"] = completionLabel
+        }
+
         return result
     }
 
@@ -206,6 +218,11 @@ struct ScheduleActionCard: Identifiable, Equatable {
         let autoDismissAfter = params["auto_dismiss_after"].flatMap { Double($0) }
         let screenBlurEnabled = params["screen_blur_enabled"].flatMap { Bool($0) } ?? false
         let screenBlurIntensity = params["screen_blur_intensity"].flatMap { BlurIntensity(rawValue: $0) } ?? .medium
+        // Absent or unparseable means no task timer — today's behaviour,
+        // unchanged (see `NotificationPreferences.taskTimerSeconds`).
+        let taskTimerSeconds = params["task_timer_seconds"].flatMap { Double($0) }
+        let taskTimerUnitLabel = params["task_timer_unit_label"]
+        let taskTimerCompletionLabel = params["task_timer_completion_label"]
 
         return NotificationPreferences(
             bundledIconId: nil, // Always nil now - IDs converted to URLs
@@ -220,7 +237,10 @@ struct ScheduleActionCard: Identifiable, Equatable {
             moveable: moveable,
             autoDismissAfter: autoDismissAfter,
             screenBlurEnabled: screenBlurEnabled,
-            screenBlurIntensity: screenBlurIntensity
+            screenBlurIntensity: screenBlurIntensity,
+            taskTimerSeconds: taskTimerSeconds,
+            taskTimerUnitLabel: taskTimerUnitLabel,
+            taskTimerCompletionLabel: taskTimerCompletionLabel
         )
     }
 }

--- a/clients/macos-swift/VibeCare/VibeCare/Views/Schedules/ActionEditSheet.swift
+++ b/clients/macos-swift/VibeCare/VibeCare/Views/Schedules/ActionEditSheet.swift
@@ -35,7 +35,8 @@ struct ActionEditSheet: View {
         self._actionType = State(initialValue: actionCard.type)
         self._viewModel = State(initialValue: NotificationActionViewModel(
             preferences: actionCard.notificationPreferences,
-            parameters: actionCard.type.seedingDefaults(into: actionCard.parameters)
+            parameters: actionCard.type.seedingDefaults(into: actionCard.parameters),
+            overridesAppearance: actionCard.overridesAppearance
         ))
     }
 
@@ -72,8 +73,9 @@ struct ActionEditSheet: View {
                         .onChange(of: actionType) { _, newType in
                             // Reset ViewModel and seed defaults for the new type
                             viewModel = NotificationActionViewModel(
-                                preferences: .default,
-                                parameters: newType.seedingDefaults(into: [:])
+                                preferences: GlobalNotificationSettings.current.basePreferences(),
+                                parameters: newType.seedingDefaults(into: [:]),
+                                overridesAppearance: false
                             )
                         }
                     }
@@ -187,6 +189,11 @@ struct ActionEditSheet: View {
             updatedCard.type = actionType
             updatedCard.parameters = viewModel.parameters
             updatedCard.notificationPreferences = viewModel.preferences
+            // Carried across so `toAction`'s own serialization pass agrees with
+            // the one `serializeToParameters()` just made — without this the
+            // card would re-add the appearance keys the view model deliberately
+            // removed.
+            updatedCard.overridesAppearance = viewModel.overridesAppearance
 
             // Convert to Action for API call
             var action = updatedCard.toAction(

--- a/clients/macos-swift/VibeCare/VibeCare/Views/Schedules/NotificationCustomizationView.swift
+++ b/clients/macos-swift/VibeCare/VibeCare/Views/Schedules/NotificationCustomizationView.swift
@@ -11,6 +11,8 @@ struct NotificationCustomizationView: View {
   @State private var showingFilePicker = false
   @State private var showingIconPicker = false
   @State private var previewNotification = false
+  /// Closed by default — see `advancedDisclosure`.
+  @State private var advancedExpanded = false
   @State private var iconPreviewData: Data?
   @State private var iconPreviewLoading = false
   @State private var iconPreviewError: Error?
@@ -26,30 +28,22 @@ struct NotificationCustomizationView: View {
 
         Spacer()
 
-        Button("Reset to Default") {
-          preferences = .default
+        Button("Reset to Global Settings") {
+          preferences = GlobalNotificationSettings.current.basePreferences()
         }
         .buttonStyle(.plain)
         .foregroundColor(.accentColor)
       }
 
-      // Preset Selector
-      presetSection
-
-      // SVG Icon Section
+      // Content: icon and wording. Always visible.
       svgIconSection
 
-      // Message Customization
       messageCustomizationSection
 
-      // Position Section
-      positionSection
-
-      // Size Controls
-      sizeSection
-
-      // Behavior Options
-      behaviorSection
+      // Appearance: demoted behind a disclosure that is closed by default,
+      // because Settings › Notifications now answers for it. Same shape as the
+      // action editor's own Advanced section.
+      advancedDisclosure
 
       // Preview Button
       previewSection
@@ -61,6 +55,28 @@ struct NotificationCustomizationView: View {
       // Load icons from backend if not already loaded
       if !iconManager.isLoaded && iconManager.loadError == nil {
         try? await iconManager.loadIcons()
+      }
+    }
+  }
+
+  // MARK: - Advanced Disclosure
+  private var advancedDisclosure: some View {
+    DisclosureGroup(isExpanded: $advancedExpanded) {
+      VStack(alignment: .leading, spacing: 20) {
+        presetSection
+        positionSection
+        sizeSection
+        behaviorSection
+      }
+      .padding(.top, 8)
+    } label: {
+      HStack(spacing: 6) {
+        Text("Advanced")
+          .font(.subheadline)
+          .fontWeight(.medium)
+        Text("Starting from your global notification settings")
+          .font(.caption)
+          .foregroundColor(.secondary)
       }
     }
   }

--- a/clients/macos-swift/VibeCare/VibeCare/Views/Settings/NotificationAppearanceSettings.swift
+++ b/clients/macos-swift/VibeCare/VibeCare/Views/Settings/NotificationAppearanceSettings.swift
@@ -1,4 +1,6 @@
+import AppKit
 import SwiftUI
+import VibeNotify
 
 /// The global notification appearance editor — the one place the user sets how
 /// notifications look, instead of repeating it on every action.
@@ -8,52 +10,57 @@ import SwiftUI
 /// gets exactly this, and an action that overrides one key keeps that key and
 /// inherits the rest. The per-action editor's Advanced disclosure is the other
 /// half of the story.
+///
+/// ## Why this looks different from the rest of Settings
+///
+/// The layout here — a right-aligned label column, controls to their right,
+/// grouped boxes, segmented controls for small choices, captions demoted to
+/// small secondary text and used sparingly — is the macOS settings idiom, and
+/// it is deliberately *not* what the neighbouring sections in `SettingsDetail`
+/// do. Those stack `Toggle`s full-width with a body-size line and a caption
+/// line inside each label, one flat run down the pane, which is a form dump:
+/// every section carries the same visual weight, the prose outweighs the
+/// controls, and the eye has nowhere to rest. This section is the largest one
+/// in the pane and had the worst of it (five full-width rectangles for a
+/// five-way choice; sliders bleeding the full width with their readouts
+/// stranded at the far edge), so the better pattern is set here rather than
+/// invented a third time somewhere else. `SettingsGroup` / `SettingsRow` /
+/// `SliderRow` below are written to be lifted into the other sections
+/// unchanged when someone does that work.
 struct NotificationAppearanceSettingsView: View {
   @EnvironmentObject private var appState: AppState
 
   @State private var settings: GlobalNotificationSettings = .current
   @State private var previewSent = false
+  /// Which simulated desktop the *preview* paints behind itself. Purely local
+  /// `@State`: it is never written to `settings`, never reaches a `notify.*`
+  /// key, and is read in exactly one place (`showPreview`). See
+  /// `PreviewDesktop`.
+  @State private var previewDesktop: PreviewDesktop = .none
   /// Coalesces a slider drag into one profile write. The local mirror is
   /// updated on every change (so the preview button is always honest); only the
   /// gRPC round trip waits.
   @State private var syncTask: Task<Void, Never>?
 
+  @StateObject private var previewDesktopWindow = PreviewDesktopController()
+
   private static let profileSyncDelay: Duration = .milliseconds(700)
 
   var body: some View {
-    VStack(alignment: .leading, spacing: 20) {
-      Text("Appearance")
-        .font(.headline)
+    VStack(alignment: .leading, spacing: 18) {
+      VStack(alignment: .leading, spacing: 2) {
+        Text("Appearance")
+          .font(.headline)
+        Text("Used by every notification unless the action that fires it overrides it.")
+          .font(.caption)
+          .foregroundStyle(.secondary)
+      }
 
-      Text("Every notification uses these unless the action that fires it overrides them.")
-        .font(.caption)
-        .foregroundColor(.secondary)
-
-      positionSection
-
-      Divider()
-
-      sizeSection
-
-      Divider()
-
-      screenBlurSection
-
-      Divider()
-
-      screenDimSection
-
-      Divider()
-
-      behaviorSection
-
-      Divider()
-
-      breakCountdownSection
-
-      Divider()
-
-      previewSection
+      layoutGroup
+      backdropGroup
+      behaviorGroup
+      breakCountdownGroup
+      previewGroup
     }
     .onChange(of: settings) { _, newValue in
       scheduleSave(newValue)
@@ -61,256 +68,226 @@ struct NotificationAppearanceSettingsView: View {
     .onAppear {
       settings = .current
     }
-  }
-
-  // MARK: - Position
-
-  private var positionSection: some View {
-    VStack(alignment: .leading, spacing: 8) {
-      Text("Position")
-        .font(.subheadline)
-        .foregroundColor(.secondary)
-
-      HStack(spacing: 12) {
-        ForEach(NotificationPosition.allCases, id: \.self) { position in
-          SelectableTile(
-            iconName: position.iconName,
-            label: position.displayName,
-            isSelected: settings.position == position
-          ) {
-            settings.position = position
-          }
-        }
-      }
-
-      Text("Full-screen alerts — screen blur, or an action with a break countdown — always cover the whole display, so position applies to the smaller floating alerts.")
-        .font(.caption)
-        .foregroundColor(.secondary)
+    // Scenery must never outlive the screen that put it up. Leaving this
+    // section — or closing the window — while a simulated desktop is painted
+    // would otherwise strand a full-screen opaque window with no control left
+    // on screen to take it down.
+    .onDisappear {
+      previewDesktopWindow.hide()
     }
   }
 
-  // MARK: - Size
+  // MARK: - Layout (position and size)
 
-  private var sizeSection: some View {
-    VStack(alignment: .leading, spacing: 12) {
-      Text("Size")
-        .font(.subheadline)
-        .foregroundColor(.secondary)
+  private var layoutGroup: some View {
+    SettingsGroup("Layout") {
+      SettingsRow(
+        "Position",
+        caption: "Applies to floating alerts. A full-screen alert covers the display."
+      ) {
+        Picker("Position", selection: $settings.position) {
+          ForEach(NotificationPosition.allCases, id: \.self) { position in
+            Image(systemName: position.iconName)
+              .accessibilityLabel(position.displayName)
+              .tag(position)
+          }
+        }
+        .pickerStyle(.segmented)
+        .labelsHidden()
+        .frame(width: 200)
+      }
 
-      LabeledSlider(
-        title: "Width",
+      SliderRow(
+        "Width",
         value: Binding(get: { Double(settings.width) }, set: { settings.width = CGFloat($0) }),
         range: 300...800,
         step: 50,
-        valueLabel: "\(Int(settings.width))"
-      )
+        readout: "\(Int(settings.width))")
 
-      LabeledSlider(
-        title: "Height",
+      SliderRow(
+        "Height",
         value: Binding(get: { Double(settings.height) }, set: { settings.height = CGFloat($0) }),
         range: 150...500,
         step: 25,
-        valueLabel: "\(Int(settings.height))"
-      )
-
-      Text("Height is a floor: an alert grows past it when its illustration or message needs the room.")
-        .font(.caption)
-        .foregroundColor(.secondary)
+        readout: "\(Int(settings.height))",
+        caption: "A floor — an alert grows past it when its content needs the room.")
     }
   }
 
-  // MARK: - Screen blur
+  // MARK: - Backdrop
 
-  private var screenBlurSection: some View {
-    VStack(alignment: .leading, spacing: 12) {
-      Text("Screen Blur")
-        .font(.subheadline)
-        .foregroundColor(.secondary)
-
-      Toggle(isOn: $settings.screenBlurEnabled) {
-        VStack(alignment: .leading, spacing: 4) {
-          Text("Blur the desktop behind notifications")
-            .font(.body)
-          Text("Turns a notification into a full-screen interruption instead of a floating alert.")
-            .font(.caption)
-            .foregroundColor(.secondary)
-        }
+  /// Blur, backdrop and dim in one box, because they are one decision: what is
+  /// behind a full-screen alert. The dim row disables itself for a painted
+  /// backdrop rather than disappearing — a control that vanishes reads as a
+  /// bug, and the caption says why it is inert.
+  private var backdropGroup: some View {
+    SettingsGroup("Full-Screen Alerts") {
+      SettingsRow(
+        "Take over the screen",
+        caption: "Turns notifications into full-screen interruptions instead of floating alerts."
+      ) {
+        Toggle("", isOn: $settings.screenBlurEnabled)
+          .toggleStyle(.switch)
+          .labelsHidden()
       }
-      .toggleStyle(.switch)
 
-      if settings.screenBlurEnabled {
-        VStack(alignment: .leading, spacing: 8) {
-          Text("Intensity")
-            .font(.caption)
-            .foregroundColor(.secondary)
-
-          HStack(spacing: 12) {
-            ForEach(BlurIntensity.allCases, id: \.self) { intensity in
-              SelectableTile(
-                iconName: intensity.iconName,
-                label: intensity.displayName,
-                isSelected: settings.screenBlurIntensity == intensity
-              ) {
-                settings.screenBlurIntensity = intensity
-              }
+      SettingsRow(
+        "Behind the alert",
+        caption: settings.backdropStyle.summary
+      ) {
+        HStack(spacing: 8) {
+          Picker("Behind the alert", selection: $settings.backdropStyle) {
+            ForEach(BackdropStyle.allCases) { style in
+              Text(style.displayName).tag(style)
             }
           }
-
-          Text("Blur controls how much desktop detail survives — not how much light. That's dimming, below.")
-            .font(.caption)
-            .foregroundColor(.secondary)
+          .labelsHidden()
+          .frame(width: 190)
+          // After the picker, not before it: left of a pop-up button a small
+          // filled rounded rect reads as a disabled text field. Reading order
+          // choice-then-sample makes it a sample.
+          BackdropSwatch(style: settings.backdropStyle)
         }
       }
-    }
-  }
 
-  // MARK: - Screen dim
+      // Disabled rather than removed for a painted backdrop, like the dim row
+      // below: the setting still exists and still applies the moment the user
+      // goes back to the blurred desktop, and a control that vanishes reads as
+      // something having gone wrong.
+      SettingsRow("Blur") {
+        Picker("Blur", selection: $settings.screenBlurIntensity) {
+          ForEach(BlurIntensity.allCases, id: \.self) { intensity in
+            Text(intensity.displayName).tag(intensity)
+          }
+        }
+        .pickerStyle(.segmented)
+        .labelsHidden()
+        .frame(width: 200)
+      }
+      .disabled(settings.backdropStyle != .blurredDesktop)
 
-  private var screenDimSection: some View {
-    VStack(alignment: .leading, spacing: 12) {
-      Text("Screen Dim")
-        .font(.subheadline)
-        .foregroundColor(.secondary)
-
-      LabeledSlider(
-        title: "Darkness behind full-screen alerts",
+      SliderRow(
+        "Dim",
         value: $settings.screenDim,
         range: GlobalNotificationSettings.screenDimRange,
         step: 0.05,
-        valueLabel: "\(Int((settings.screenDim * 100).rounded()))%"
+        readout: "\(Int((settings.screenDim * 100).rounded()))%",
+        caption: dimCaption
       )
+      .disabled(settings.backdropStyle != .blurredDesktop)
 
-      VStack(alignment: .leading, spacing: 6) {
-        Text(
-          "Dimming, not blurring, is what makes the text readable. At \(Int((GlobalNotificationSettings.wcagSafeScreenDim * 100).rounded()))% white text clears WCAG AA contrast over any desktop — even a pure white one."
-        )
-        .font(.caption)
-        .foregroundColor(.secondary)
-
-        if settings.screenDim < GlobalNotificationSettings.wcagSafeScreenDim {
-          HStack(alignment: .top, spacing: 6) {
+      if settings.backdropStyle == .blurredDesktop,
+        settings.screenDim < GlobalNotificationSettings.wcagSafeScreenDim
+      {
+        SettingsRow("") {
+          HStack(spacing: 6) {
             Image(systemName: "exclamationmark.triangle.fill")
-              .foregroundColor(.orange)
-            Text(
-              "Below \(Int((GlobalNotificationSettings.wcagSafeScreenDim * 100).rounded()))% the desktop shows through more, so alerts fall back to drawing their own shading behind the text."
-            )
-            .font(.caption)
-            .foregroundColor(.secondary)
+              .foregroundStyle(.orange)
+            Text("Below the readable minimum — alerts fall back to shading their own text.")
+              .font(.caption)
+              .foregroundStyle(.secondary)
+            Button("Fix") {
+              settings.screenDim = GlobalNotificationSettings.wcagSafeScreenDim
+            }
+            .controlSize(.small)
           }
-
-          Button("Use the readable minimum") {
-            settings.screenDim = GlobalNotificationSettings.wcagSafeScreenDim
-          }
-          .buttonStyle(.bordered)
-          .controlSize(.small)
         }
       }
-
-      Text("Only applies to full-screen alerts; a floating alert leaves the desktop's light alone.")
-        .font(.caption)
-        .foregroundColor(.secondary)
     }
+  }
+
+  private var dimCaption: String {
+    guard settings.backdropStyle == .blurredDesktop else {
+      return "A painted backdrop hides the desktop, so there is no light left to dim."
+    }
+    let safe = Int((GlobalNotificationSettings.wcagSafeScreenDim * 100).rounded())
+    return "At \(safe)% white text clears WCAG AA over any desktop."
   }
 
   // MARK: - Behavior
 
-  private var behaviorSection: some View {
-    VStack(alignment: .leading, spacing: 12) {
-      Text("Behavior")
-        .font(.subheadline)
-        .foregroundColor(.secondary)
-
-      Toggle(isOn: $settings.moveable) {
-        VStack(alignment: .leading, spacing: 4) {
-          Text("Allow moving the notification")
-            .font(.body)
-          Text("Drag a floating alert out of the way instead of dismissing it.")
-            .font(.caption)
-            .foregroundColor(.secondary)
-        }
+  private var behaviorGroup: some View {
+    SettingsGroup("Behavior") {
+      SettingsRow("Draggable", caption: "Move a floating alert aside instead of dismissing it.") {
+        Toggle("", isOn: $settings.moveable)
+          .toggleStyle(.switch)
+          .labelsHidden()
       }
-      .toggleStyle(.switch)
 
-      LabeledSlider(
-        title: "Auto-dismiss after",
+      SliderRow(
+        "Auto-dismiss",
         value: $settings.autoDismissAfter,
         range: 5...60,
         step: 5,
-        valueLabel: "\(Int(settings.autoDismissAfter))s"
-      )
-
-      Text("Ignored while a break countdown is running — the break's own timer owns the alert's lifetime.")
-        .font(.caption)
-        .foregroundColor(.secondary)
+        readout: "\(Int(settings.autoDismissAfter))s",
+        caption: "Ignored while a break countdown is running.")
     }
   }
 
   // MARK: - Break countdown
 
-  private var breakCountdownSection: some View {
-    VStack(alignment: .leading, spacing: 12) {
-      Text("Break Countdown")
-        .font(.subheadline)
-        .foregroundColor(.secondary)
+  private var breakCountdownGroup: some View {
+    SettingsGroup("Break Countdown") {
+      SettingsRow("Unit label") {
+        TextField("seconds", text: $settings.breakUnitLabel)
+          .textFieldStyle(.roundedBorder)
+          .frame(width: 200)
+      }
 
-      Text("Wording for the big countdown ring an action shows when it sets a break duration.")
-        .font(.caption)
-        .foregroundColor(.secondary)
-
-      HStack(spacing: 16) {
-        VStack(alignment: .leading, spacing: 4) {
-          Text("Unit label")
-            .font(.caption)
-            .foregroundColor(.secondary)
-          TextField("seconds", text: $settings.breakUnitLabel)
-            .textFieldStyle(.roundedBorder)
-        }
-
-        VStack(alignment: .leading, spacing: 4) {
-          Text("Completion label")
-            .font(.caption)
-            .foregroundColor(.secondary)
-          TextField("Break complete", text: $settings.breakCompletionLabel)
-            .textFieldStyle(.roundedBorder)
-        }
+      SettingsRow(
+        "Completion label",
+        caption: "Wording for the big ring an action shows when it sets a break duration."
+      ) {
+        TextField("Break complete", text: $settings.breakCompletionLabel)
+          .textFieldStyle(.roundedBorder)
+          .frame(width: 200)
       }
     }
   }
 
   // MARK: - Preview
 
-  private var previewSection: some View {
-    VStack(alignment: .leading, spacing: 8) {
-      HStack(spacing: 12) {
-        Button {
-          showPreview()
-        } label: {
-          Label("Preview Notification", systemImage: "eye")
-        }
-        .buttonStyle(.borderedProminent)
-
-        Button("Reset to Defaults") {
-          settings = .fallback
-        }
-        .buttonStyle(.bordered)
-
-        if previewSent {
-          HStack(spacing: 4) {
-            Image(systemName: "checkmark.circle.fill")
-              .foregroundColor(.green)
-            Text("Preview sent")
-              .font(.caption)
-              .foregroundColor(.secondary)
+  private var previewGroup: some View {
+    SettingsGroup("Preview") {
+      SettingsRow(
+        "",
+        caption: "Fires through the same path a real schedule notification takes."
+      ) {
+        HStack(spacing: 10) {
+          Button {
+            showPreview()
+          } label: {
+            Label("Preview", systemImage: "eye")
           }
-          .transition(.opacity)
-        }
+          .buttonStyle(.borderedProminent)
 
-        Spacer()
+          Button("Reset to Defaults") {
+            settings = .fallback
+          }
+
+          if previewSent {
+            Image(systemName: "checkmark.circle.fill")
+              .foregroundStyle(.green)
+              .help("Preview sent")
+              .transition(.opacity)
+          }
+        }
       }
 
-      Text("Renders through the same path a real schedule notification takes, so what you see is what you'll get.")
-        .font(.caption)
-        .foregroundColor(.secondary)
+      SettingsRow(
+        "Test against",
+        caption:
+          "A fake desktop painted behind the preview only, to judge legibility without rearranging windows. Real notifications never paint it."
+      ) {
+        Picker("Test against", selection: $previewDesktop) {
+          ForEach(PreviewDesktop.allCases) { desktop in
+            Text(desktop.displayName).tag(desktop)
+          }
+        }
+        .labelsHidden()
+        .controlSize(.small)
+        .frame(width: 190)
+      }
     }
   }
 
@@ -320,19 +297,42 @@ struct NotificationAppearanceSettingsView: View {
   /// the same funnel the three per-action preview buttons and every delivered
   /// schedule alert use. A preview rendered any other way would teach a layout
   /// the user is never going to get.
+  ///
+  /// The simulated desktop is scenery put up *around* that call and taken down
+  /// when the overlay it was staged for ends. It is deliberately not a
+  /// parameter of the funnel: nothing about `showScheduleNotification`,
+  /// `NotificationPreferences` or the persisted `notify.*` keys knows this
+  /// exists, so there is no path by which a real alert could paint one — the
+  /// only way to see it is to press this button with this picker set.
   private func showPreview() {
-    // Flush before previewing: the funnel reads the persisted screen dim, and
-    // an in-flight slider edit that has not landed yet would preview the old
-    // one.
+    // Flush before previewing: the funnel reads the persisted screen dim and
+    // backdrop, and an in-flight slider edit that has not landed yet would
+    // preview the old one.
     settings.persistLocally()
 
-    _ = VibeNotifyConfig.showScheduleNotification(
+    previewDesktopWindow.show(previewDesktop)
+
+    let id = VibeNotifyConfig.showScheduleNotification(
       scheduleName: "Preview Notification",
       routineName: "Global notification settings",
       scheduledTime: Date(),
       notes: nil,
       preferences: settings.basePreferences()
     )
+
+    if let id {
+      // Deterministic teardown rather than a timer: the preview can end by
+      // ESC, a click, a button or its own auto-dismiss, and every one of those
+      // has to take the scenery with it.
+      OverlayWindowManager.shared.addEndHandler(id: id) { _ in
+        previewDesktopWindow.hide()
+      }
+    } else {
+      // `showScheduleNotification` returns nil when a `NotificationPolicy`
+      // guard refuses the alert. No overlay means no end event, so the scenery
+      // would otherwise stay up forever with nothing behind it.
+      previewDesktopWindow.hide()
+    }
 
     withAnimation { previewSent = true }
     DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
@@ -351,59 +351,294 @@ struct NotificationAppearanceSettingsView: View {
   }
 }
 
-// MARK: - Shared Controls
+// MARK: - Settings chrome
 
-/// The icon-over-label tile the per-action position and blur-intensity pickers
-/// already use, factored out so both settings surfaces stay identical rather
-/// than similar.
-struct SelectableTile: View {
-  let iconName: String
-  let label: String
-  let isSelected: Bool
-  let action: () -> Void
+/// A titled, bordered group of rows — the container macOS settings panes put
+/// related controls in, and the thing this screen had none of.
+struct SettingsGroup<Content: View>: View {
+  private let title: String
+  private let content: Content
+
+  init(_ title: String, @ViewBuilder content: () -> Content) {
+    self.title = title
+    self.content = content()
+  }
 
   var body: some View {
-    Button(action: action) {
-      VStack(spacing: 4) {
-        Image(systemName: iconName)
-          .font(.title3)
-        Text(label)
-          .font(.caption)
+    VStack(alignment: .leading, spacing: 6) {
+      Text(title)
+        .font(.subheadline)
+        .fontWeight(.semibold)
+        .foregroundStyle(.secondary)
+
+      VStack(alignment: .leading, spacing: 12) {
+        content
       }
-      .frame(maxWidth: .infinity)
-      .padding(.vertical, 12)
-      .background(isSelected ? Color.accentColor : Color(NSColor.controlBackgroundColor))
-      .foregroundColor(isSelected ? .white : .primary)
-      .cornerRadius(8)
+      .padding(14)
+      .frame(maxWidth: .infinity, alignment: .leading)
+      .background(
+        RoundedRectangle(cornerRadius: 8)
+          .fill(Color(NSColor.controlBackgroundColor))
+      )
+      .overlay(
+        RoundedRectangle(cornerRadius: 8)
+          .strokeBorder(Color(NSColor.separatorColor), lineWidth: 1)
+      )
     }
-    .buttonStyle(.plain)
   }
 }
 
-/// A slider with the caption label and trailing readout the existing
-/// customization sheets use.
-struct LabeledSlider: View {
-  let title: String
-  @Binding var value: Double
-  let range: ClosedRange<Double>
-  let step: Double
-  let valueLabel: String
+/// One row: label in a fixed right-aligned column, control to its right, and an
+/// optional caption *under the control* at caption size.
+///
+/// The fixed column is what produces the vertical rhythm macOS settings have
+/// and this screen did not: every control in the pane starts at the same x, so
+/// the eye reads a column of controls rather than a wall of stacked blocks. An
+/// empty `label` keeps a row aligned to that column without repeating a title
+/// the control already carries.
+struct SettingsRow<Control: View>: View {
+  private let label: String
+  private let caption: String?
+  private let control: Control
+
+  static var labelColumnWidth: CGFloat { 132 }
+
+  init(_ label: String, caption: String? = nil, @ViewBuilder control: () -> Control) {
+    self.label = label
+    self.caption = caption
+    self.control = control()
+  }
 
   var body: some View {
-    VStack(alignment: .leading, spacing: 4) {
-      Text(title)
-        .font(.caption)
-        .foregroundColor(.secondary)
+    HStack(alignment: .firstTextBaseline, spacing: 10) {
+      Text(label)
+        .frame(width: Self.labelColumnWidth, alignment: .trailing)
 
-      HStack {
+      VStack(alignment: .leading, spacing: 4) {
+        control
+        if let caption {
+          Text(caption)
+            .font(.caption)
+            .foregroundStyle(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+        }
+      }
+      .frame(maxWidth: .infinity, alignment: .leading)
+    }
+  }
+}
+
+/// A `SettingsRow` whose control is a slider with its readout **immediately to
+/// its right**, not at the far edge of the pane.
+///
+/// That is the whole point of the fixed slider width: a full-bleed slider puts
+/// the number a screen away from the handle it describes, so reading a value
+/// means a saccade across the entire window.
+struct SliderRow: View {
+  private let label: String
+  @Binding private var value: Double
+  private let range: ClosedRange<Double>
+  private let step: Double
+  private let readout: String
+  private let caption: String?
+
+  init(
+    _ label: String,
+    value: Binding<Double>,
+    range: ClosedRange<Double>,
+    step: Double,
+    readout: String,
+    caption: String? = nil
+  ) {
+    self.label = label
+    self._value = value
+    self.range = range
+    self.step = step
+    self.readout = readout
+    self.caption = caption
+  }
+
+  var body: some View {
+    SettingsRow(label, caption: caption) {
+      HStack(spacing: 8) {
         Slider(value: $value, in: range, step: step)
-
-        Text(valueLabel)
-          .font(.caption)
-          .foregroundColor(.secondary)
-          .frame(width: 44, alignment: .trailing)
+          .frame(width: 200)
+        Text(readout)
+          .font(.callout)
           .monospacedDigit()
+          .foregroundStyle(.secondary)
+          .frame(width: 42, alignment: .leading)
       }
     }
+  }
+}
+
+/// The chosen backdrop, drawn. A name alone ("Deep Sea") does not tell anyone
+/// what they are about to stare at for twenty seconds.
+struct BackdropSwatch: View {
+  let style: BackdropStyle
+
+  var body: some View {
+    RoundedRectangle(cornerRadius: 4)
+      .fill(fill)
+      .frame(width: 34, height: 20)
+      .overlay(
+        RoundedRectangle(cornerRadius: 4)
+          .strokeBorder(Color(NSColor.separatorColor), lineWidth: 1)
+      )
+  }
+
+  private var fill: AnyShapeStyle {
+    guard let fill = style.fill else {
+      // The blurred desktop has no colour of its own to show — it is whatever
+      // the desktop happens to be — so this stands for "dimmed desktop"
+      // rather than pretending to a specific tone.
+      return AnyShapeStyle(
+        LinearGradient(
+          colors: [Color(white: 0.30), Color(white: 0.12)],
+          startPoint: .topLeading, endPoint: .bottomTrailing))
+    }
+    return AnyShapeStyle(
+      LinearGradient(
+        colors: fill.stops.map(\.color),
+        startPoint: .topLeading,
+        endPoint: .bottomTrailing))
+  }
+}
+
+// MARK: - Preview desktop (a testing affordance)
+
+/// A fake desktop painted behind a *preview* alert, so legibility can be judged
+/// against a hostile surface without rearranging real windows.
+///
+/// Ported from the library's demo harness (`VibeNotifyDemo/Sources/Backdrop.swift`),
+/// including its option set, because those options were chosen for a reason:
+/// `.splitBlackWhite` is the desktop that produced the original bug — a dark
+/// terminal on one half, a white browser on the other, with the title straddling
+/// the seam — and the rest stress the same invariant from other angles.
+///
+/// **This is not a setting.** It lives in view `@State`, it is not part of
+/// `GlobalNotificationSettings`, it has no `notify.*` key, and it is read at
+/// exactly one call site. A delivered notification cannot reach it.
+enum PreviewDesktop: String, CaseIterable, Identifiable {
+  case none
+  case splitBlackWhite
+  case white
+  case midGrey
+  case saturatedGradient
+  case busyPattern
+
+  var id: String { rawValue }
+
+  var displayName: String {
+    switch self {
+    case .none: return "Nothing (real desktop)"
+    case .splitBlackWhite: return "Split black / white"
+    case .white: return "Solid white"
+    case .midGrey: return "Mid-grey field"
+    case .saturatedGradient: return "Saturated gradient"
+    case .busyPattern: return "Busy pattern"
+    }
+  }
+}
+
+/// Paints a `PreviewDesktop` full-bleed.
+private struct PreviewDesktopView: View {
+  let desktop: PreviewDesktop
+
+  var body: some View {
+    switch desktop {
+    case .none:
+      Color.clear
+    case .splitBlackWhite:
+      HStack(spacing: 0) {
+        Color.black
+        Color.white
+      }
+    case .white:
+      Color.white
+    case .midGrey:
+      Color(white: 0.5)
+    case .saturatedGradient:
+      LinearGradient(
+        colors: [
+          Color(red: 0.98, green: 0.42, blue: 0.16),
+          Color(red: 0.78, green: 0.09, blue: 0.62),
+          Color(red: 0.06, green: 0.42, blue: 0.86),
+        ],
+        startPoint: .topLeading,
+        endPoint: .bottomTrailing)
+    case .busyPattern:
+      Canvas { context, size in
+        let cell: CGFloat = 8
+        var x: CGFloat = 0
+        var row = 0
+        while x < size.width {
+          var y: CGFloat = 0
+          var col = 0
+          while y < size.height {
+            let dark = (row + col).isMultiple(of: 2)
+            context.fill(
+              Path(CGRect(x: x, y: y, width: cell, height: cell)),
+              with: .color(dark ? .black : .white))
+            y += cell
+            col += 1
+          }
+          x += cell
+          row += 1
+        }
+      }
+    }
+  }
+}
+
+/// Owns the single borderless window a `PreviewDesktop` is painted into.
+///
+/// **Window level.** The point of this window is to stand in for the user's
+/// real desktop, so it has to render *above* the ordinary windows that are
+/// already open — one step above `NSWindow.Level.normal`. That is still well
+/// below the alert's own windows (`.floating` for the content window,
+/// `.floating - 1` for the backdrop window), so the stacking a user sees is:
+/// real windows, this fake desktop, the alert's backdrop, the alert. It does
+/// cover this Settings window while it is up, which is correct — a full-screen
+/// preview covers it anyway, and it comes down with the alert.
+@MainActor
+final class PreviewDesktopController: ObservableObject {
+  private var window: NSWindow?
+
+  func show(_ desktop: PreviewDesktop) {
+    guard desktop != .none, let screen = NSScreen.main else {
+      hide()
+      return
+    }
+
+    let win =
+      window
+      ?? {
+        let created = NSWindow(
+          contentRect: screen.frame,
+          styleMask: [.borderless],
+          backing: .buffered,
+          defer: false,
+          screen: screen)
+        created.isOpaque = true
+        created.hasShadow = false
+        created.isReleasedWhenClosed = false
+        // Scenery, not UI: never intercepts a click, so anything it covers
+        // stays reachable.
+        created.ignoresMouseEvents = true
+        created.level = NSWindow.Level(rawValue: NSWindow.Level.normal.rawValue + 1)
+        created.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .stationary]
+        window = created
+        return created
+      }()
+
+    win.setFrame(screen.frame, display: true)
+    win.contentView = NSHostingView(rootView: PreviewDesktopView(desktop: desktop))
+    win.orderFrontRegardless()
+  }
+
+  func hide() {
+    window?.orderOut(nil)
   }
 }

--- a/clients/macos-swift/VibeCare/VibeCare/Views/Settings/NotificationAppearanceSettings.swift
+++ b/clients/macos-swift/VibeCare/VibeCare/Views/Settings/NotificationAppearanceSettings.swift
@@ -1,0 +1,409 @@
+import SwiftUI
+
+/// The global notification appearance editor — the one place the user sets how
+/// notifications look, instead of repeating it on every action.
+///
+/// Every control here writes `GlobalNotificationSettings`, which is the bottom
+/// of the resolution stack: an action that says nothing about its appearance
+/// gets exactly this, and an action that overrides one key keeps that key and
+/// inherits the rest. The per-action editor's Advanced disclosure is the other
+/// half of the story.
+struct NotificationAppearanceSettingsView: View {
+  @EnvironmentObject private var appState: AppState
+
+  @State private var settings: GlobalNotificationSettings = .current
+  @State private var previewSent = false
+  /// Coalesces a slider drag into one profile write. The local mirror is
+  /// updated on every change (so the preview button is always honest); only the
+  /// gRPC round trip waits.
+  @State private var syncTask: Task<Void, Never>?
+
+  private static let profileSyncDelay: Duration = .milliseconds(700)
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 20) {
+      Text("Appearance")
+        .font(.headline)
+
+      Text("Every notification uses these unless the action that fires it overrides them.")
+        .font(.caption)
+        .foregroundColor(.secondary)
+
+      positionSection
+
+      Divider()
+
+      sizeSection
+
+      Divider()
+
+      screenBlurSection
+
+      Divider()
+
+      screenDimSection
+
+      Divider()
+
+      behaviorSection
+
+      Divider()
+
+      breakCountdownSection
+
+      Divider()
+
+      previewSection
+    }
+    .onChange(of: settings) { _, newValue in
+      scheduleSave(newValue)
+    }
+    .onAppear {
+      settings = .current
+    }
+  }
+
+  // MARK: - Position
+
+  private var positionSection: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      Text("Position")
+        .font(.subheadline)
+        .foregroundColor(.secondary)
+
+      HStack(spacing: 12) {
+        ForEach(NotificationPosition.allCases, id: \.self) { position in
+          SelectableTile(
+            iconName: position.iconName,
+            label: position.displayName,
+            isSelected: settings.position == position
+          ) {
+            settings.position = position
+          }
+        }
+      }
+
+      Text("Full-screen alerts — screen blur, or an action with a break countdown — always cover the whole display, so position applies to the smaller floating alerts.")
+        .font(.caption)
+        .foregroundColor(.secondary)
+    }
+  }
+
+  // MARK: - Size
+
+  private var sizeSection: some View {
+    VStack(alignment: .leading, spacing: 12) {
+      Text("Size")
+        .font(.subheadline)
+        .foregroundColor(.secondary)
+
+      LabeledSlider(
+        title: "Width",
+        value: Binding(get: { Double(settings.width) }, set: { settings.width = CGFloat($0) }),
+        range: 300...800,
+        step: 50,
+        valueLabel: "\(Int(settings.width))"
+      )
+
+      LabeledSlider(
+        title: "Height",
+        value: Binding(get: { Double(settings.height) }, set: { settings.height = CGFloat($0) }),
+        range: 150...500,
+        step: 25,
+        valueLabel: "\(Int(settings.height))"
+      )
+
+      Text("Height is a floor: an alert grows past it when its illustration or message needs the room.")
+        .font(.caption)
+        .foregroundColor(.secondary)
+    }
+  }
+
+  // MARK: - Screen blur
+
+  private var screenBlurSection: some View {
+    VStack(alignment: .leading, spacing: 12) {
+      Text("Screen Blur")
+        .font(.subheadline)
+        .foregroundColor(.secondary)
+
+      Toggle(isOn: $settings.screenBlurEnabled) {
+        VStack(alignment: .leading, spacing: 4) {
+          Text("Blur the desktop behind notifications")
+            .font(.body)
+          Text("Turns a notification into a full-screen interruption instead of a floating alert.")
+            .font(.caption)
+            .foregroundColor(.secondary)
+        }
+      }
+      .toggleStyle(.switch)
+
+      if settings.screenBlurEnabled {
+        VStack(alignment: .leading, spacing: 8) {
+          Text("Intensity")
+            .font(.caption)
+            .foregroundColor(.secondary)
+
+          HStack(spacing: 12) {
+            ForEach(BlurIntensity.allCases, id: \.self) { intensity in
+              SelectableTile(
+                iconName: intensity.iconName,
+                label: intensity.displayName,
+                isSelected: settings.screenBlurIntensity == intensity
+              ) {
+                settings.screenBlurIntensity = intensity
+              }
+            }
+          }
+
+          Text("Blur controls how much desktop detail survives — not how much light. That's dimming, below.")
+            .font(.caption)
+            .foregroundColor(.secondary)
+        }
+      }
+    }
+  }
+
+  // MARK: - Screen dim
+
+  private var screenDimSection: some View {
+    VStack(alignment: .leading, spacing: 12) {
+      Text("Screen Dim")
+        .font(.subheadline)
+        .foregroundColor(.secondary)
+
+      LabeledSlider(
+        title: "Darkness behind full-screen alerts",
+        value: $settings.screenDim,
+        range: GlobalNotificationSettings.screenDimRange,
+        step: 0.05,
+        valueLabel: "\(Int((settings.screenDim * 100).rounded()))%"
+      )
+
+      VStack(alignment: .leading, spacing: 6) {
+        Text(
+          "Dimming, not blurring, is what makes the text readable. At \(Int((GlobalNotificationSettings.wcagSafeScreenDim * 100).rounded()))% white text clears WCAG AA contrast over any desktop — even a pure white one."
+        )
+        .font(.caption)
+        .foregroundColor(.secondary)
+
+        if settings.screenDim < GlobalNotificationSettings.wcagSafeScreenDim {
+          HStack(alignment: .top, spacing: 6) {
+            Image(systemName: "exclamationmark.triangle.fill")
+              .foregroundColor(.orange)
+            Text(
+              "Below \(Int((GlobalNotificationSettings.wcagSafeScreenDim * 100).rounded()))% the desktop shows through more, so alerts fall back to drawing their own shading behind the text."
+            )
+            .font(.caption)
+            .foregroundColor(.secondary)
+          }
+
+          Button("Use the readable minimum") {
+            settings.screenDim = GlobalNotificationSettings.wcagSafeScreenDim
+          }
+          .buttonStyle(.bordered)
+          .controlSize(.small)
+        }
+      }
+
+      Text("Only applies to full-screen alerts; a floating alert leaves the desktop's light alone.")
+        .font(.caption)
+        .foregroundColor(.secondary)
+    }
+  }
+
+  // MARK: - Behavior
+
+  private var behaviorSection: some View {
+    VStack(alignment: .leading, spacing: 12) {
+      Text("Behavior")
+        .font(.subheadline)
+        .foregroundColor(.secondary)
+
+      Toggle(isOn: $settings.moveable) {
+        VStack(alignment: .leading, spacing: 4) {
+          Text("Allow moving the notification")
+            .font(.body)
+          Text("Drag a floating alert out of the way instead of dismissing it.")
+            .font(.caption)
+            .foregroundColor(.secondary)
+        }
+      }
+      .toggleStyle(.switch)
+
+      LabeledSlider(
+        title: "Auto-dismiss after",
+        value: $settings.autoDismissAfter,
+        range: 5...60,
+        step: 5,
+        valueLabel: "\(Int(settings.autoDismissAfter))s"
+      )
+
+      Text("Ignored while a break countdown is running — the break's own timer owns the alert's lifetime.")
+        .font(.caption)
+        .foregroundColor(.secondary)
+    }
+  }
+
+  // MARK: - Break countdown
+
+  private var breakCountdownSection: some View {
+    VStack(alignment: .leading, spacing: 12) {
+      Text("Break Countdown")
+        .font(.subheadline)
+        .foregroundColor(.secondary)
+
+      Text("Wording for the big countdown ring an action shows when it sets a break duration.")
+        .font(.caption)
+        .foregroundColor(.secondary)
+
+      HStack(spacing: 16) {
+        VStack(alignment: .leading, spacing: 4) {
+          Text("Unit label")
+            .font(.caption)
+            .foregroundColor(.secondary)
+          TextField("seconds", text: $settings.breakUnitLabel)
+            .textFieldStyle(.roundedBorder)
+        }
+
+        VStack(alignment: .leading, spacing: 4) {
+          Text("Completion label")
+            .font(.caption)
+            .foregroundColor(.secondary)
+          TextField("Break complete", text: $settings.breakCompletionLabel)
+            .textFieldStyle(.roundedBorder)
+        }
+      }
+    }
+  }
+
+  // MARK: - Preview
+
+  private var previewSection: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      HStack(spacing: 12) {
+        Button {
+          showPreview()
+        } label: {
+          Label("Preview Notification", systemImage: "eye")
+        }
+        .buttonStyle(.borderedProminent)
+
+        Button("Reset to Defaults") {
+          settings = .fallback
+        }
+        .buttonStyle(.bordered)
+
+        if previewSent {
+          HStack(spacing: 4) {
+            Image(systemName: "checkmark.circle.fill")
+              .foregroundColor(.green)
+            Text("Preview sent")
+              .font(.caption)
+              .foregroundColor(.secondary)
+          }
+          .transition(.opacity)
+        }
+
+        Spacer()
+      }
+
+      Text("Renders through the same path a real schedule notification takes, so what you see is what you'll get.")
+        .font(.caption)
+        .foregroundColor(.secondary)
+    }
+  }
+
+  // MARK: - Actions
+
+  /// The preview goes through `VibeNotifyConfig.showScheduleNotification` —
+  /// the same funnel the three per-action preview buttons and every delivered
+  /// schedule alert use. A preview rendered any other way would teach a layout
+  /// the user is never going to get.
+  private func showPreview() {
+    // Flush before previewing: the funnel reads the persisted screen dim, and
+    // an in-flight slider edit that has not landed yet would preview the old
+    // one.
+    settings.persistLocally()
+
+    _ = VibeNotifyConfig.showScheduleNotification(
+      scheduleName: "Preview Notification",
+      routineName: "Global notification settings",
+      scheduledTime: Date(),
+      notes: nil,
+      preferences: settings.basePreferences()
+    )
+
+    withAnimation { previewSent = true }
+    DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+      withAnimation { previewSent = false }
+    }
+  }
+
+  private func scheduleSave(_ newValue: GlobalNotificationSettings) {
+    newValue.persistLocally()
+    syncTask?.cancel()
+    syncTask = Task {
+      try? await Task.sleep(for: Self.profileSyncDelay)
+      guard !Task.isCancelled else { return }
+      appState.saveGlobalNotificationSettings(newValue)
+    }
+  }
+}
+
+// MARK: - Shared Controls
+
+/// The icon-over-label tile the per-action position and blur-intensity pickers
+/// already use, factored out so both settings surfaces stay identical rather
+/// than similar.
+struct SelectableTile: View {
+  let iconName: String
+  let label: String
+  let isSelected: Bool
+  let action: () -> Void
+
+  var body: some View {
+    Button(action: action) {
+      VStack(spacing: 4) {
+        Image(systemName: iconName)
+          .font(.title3)
+        Text(label)
+          .font(.caption)
+      }
+      .frame(maxWidth: .infinity)
+      .padding(.vertical, 12)
+      .background(isSelected ? Color.accentColor : Color(NSColor.controlBackgroundColor))
+      .foregroundColor(isSelected ? .white : .primary)
+      .cornerRadius(8)
+    }
+    .buttonStyle(.plain)
+  }
+}
+
+/// A slider with the caption label and trailing readout the existing
+/// customization sheets use.
+struct LabeledSlider: View {
+  let title: String
+  @Binding var value: Double
+  let range: ClosedRange<Double>
+  let step: Double
+  let valueLabel: String
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 4) {
+      Text(title)
+        .font(.caption)
+        .foregroundColor(.secondary)
+
+      HStack {
+        Slider(value: $value, in: range, step: step)
+
+        Text(valueLabel)
+          .font(.caption)
+          .foregroundColor(.secondary)
+          .frame(width: 44, alignment: .trailing)
+          .monospacedDigit()
+      }
+    }
+  }
+}

--- a/clients/macos-swift/VibeCare/VibeCare/Views/Settings/SettingsDetail.swift
+++ b/clients/macos-swift/VibeCare/VibeCare/Views/Settings/SettingsDetail.swift
@@ -613,6 +613,11 @@ struct NotificationsSettingsDetail: View {
 
       Divider()
 
+      // Global appearance — the defaults every notification inherits.
+      NotificationAppearanceSettingsView()
+
+      Divider()
+
       // Future features
       Text("Advanced Features")
         .font(.headline)

--- a/clients/macos-swift/VibeCare/vibecare.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/clients/macos-swift/VibeCare/vibecare.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,276 +1,276 @@
 {
-  "originHash" : "259dbf69b6564f2bae4268ff1c017cf0f862e96c5a999abefcbf7c5e791cc7cc",
-  "pins" : [
+  "originHash": "259dbf69b6564f2bae4268ff1c017cf0f862e96c5a999abefcbf7c5e791cc7cc",
+  "pins": [
     {
-      "identity" : "grpc-swift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/grpc/grpc-swift.git",
-      "state" : {
-        "revision" : "a56a157218877ef3e9625f7e1f7b2cb7e46ead1b",
-        "version" : "1.26.1"
+      "identity": "grpc-swift",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/grpc/grpc-swift.git",
+      "state": {
+        "revision": "a56a157218877ef3e9625f7e1f7b2cb7e46ead1b",
+        "version": "1.26.1"
       }
     },
     {
-      "identity" : "grpc-swift-2",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/grpc/grpc-swift-2",
-      "state" : {
-        "revision" : "0e52abf7ea0fca7ffe876953aa41feff84cc6e29",
-        "version" : "2.1.0"
+      "identity": "grpc-swift-2",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/grpc/grpc-swift-2",
+      "state": {
+        "revision": "0e52abf7ea0fca7ffe876953aa41feff84cc6e29",
+        "version": "2.1.0"
       }
     },
     {
-      "identity" : "grpc-swift-nio-transport",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/grpc/grpc-swift-nio-transport.git",
-      "state" : {
-        "revision" : "0393731de32c472e3bcdb7f339ecf55cc607a6b4",
-        "version" : "2.2.0"
+      "identity": "grpc-swift-nio-transport",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/grpc/grpc-swift-nio-transport.git",
+      "state": {
+        "revision": "0393731de32c472e3bcdb7f339ecf55cc607a6b4",
+        "version": "2.2.0"
       }
     },
     {
-      "identity" : "grpc-swift-protobuf",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/grpc/grpc-swift-protobuf.git",
-      "state" : {
-        "revision" : "c008d356d9e9c2255602711888bf25b542a30919",
-        "version" : "2.1.1"
+      "identity": "grpc-swift-protobuf",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/grpc/grpc-swift-protobuf.git",
+      "state": {
+        "revision": "c008d356d9e9c2255602711888bf25b542a30919",
+        "version": "2.1.1"
       }
     },
     {
-      "identity" : "opentelemetry-swift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/open-telemetry/opentelemetry-swift.git",
-      "state" : {
-        "revision" : "0b77b8e2b2121261562b1d304c638a004e1d2f19",
-        "version" : "2.2.0"
+      "identity": "opentelemetry-swift",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/open-telemetry/opentelemetry-swift.git",
+      "state": {
+        "revision": "0b77b8e2b2121261562b1d304c638a004e1d2f19",
+        "version": "2.2.0"
       }
     },
     {
-      "identity" : "opentelemetry-swift-core",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/open-telemetry/opentelemetry-swift-core.git",
-      "state" : {
-        "revision" : "fd787757decabfa93319cc3c04f03a49e0cf40b6",
-        "version" : "2.2.0"
+      "identity": "opentelemetry-swift-core",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/open-telemetry/opentelemetry-swift-core.git",
+      "state": {
+        "revision": "fd787757decabfa93319cc3c04f03a49e0cf40b6",
+        "version": "2.2.0"
       }
     },
     {
-      "identity" : "opentracing-objc",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/undefinedlabs/opentracing-objc",
-      "state" : {
-        "revision" : "18c1a35ca966236cee0c5a714a51a73ff33384c1",
-        "version" : "0.5.2"
+      "identity": "opentracing-objc",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/undefinedlabs/opentracing-objc",
+      "state": {
+        "revision": "18c1a35ca966236cee0c5a714a51a73ff33384c1",
+        "version": "0.5.2"
       }
     },
     {
-      "identity" : "svgview",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/exyte/SVGView.git",
-      "state" : {
-        "revision" : "6465962facdd25cb96eaebc35603afa2f15d2c0d",
-        "version" : "1.0.6"
+      "identity": "svgview",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/exyte/SVGView.git",
+      "state": {
+        "revision": "6465962facdd25cb96eaebc35603afa2f15d2c0d",
+        "version": "1.0.6"
       }
     },
     {
-      "identity" : "swift-algorithms",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-algorithms.git",
-      "state" : {
-        "revision" : "87e50f483c54e6efd60e885f7f5aa946cee68023",
-        "version" : "1.2.1"
+      "identity": "swift-algorithms",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/apple/swift-algorithms.git",
+      "state": {
+        "revision": "87e50f483c54e6efd60e885f7f5aa946cee68023",
+        "version": "1.2.1"
       }
     },
     {
-      "identity" : "swift-asn1",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-asn1.git",
-      "state" : {
-        "revision" : "f70225981241859eb4aa1a18a75531d26637c8cc",
-        "version" : "1.4.0"
+      "identity": "swift-asn1",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/apple/swift-asn1.git",
+      "state": {
+        "revision": "f70225981241859eb4aa1a18a75531d26637c8cc",
+        "version": "1.4.0"
       }
     },
     {
-      "identity" : "swift-async-algorithms",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-async-algorithms.git",
-      "state" : {
-        "revision" : "042e1c4d9d19748c9c228f8d4ebc97bb1e339b0b",
-        "version" : "1.0.4"
+      "identity": "swift-async-algorithms",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/apple/swift-async-algorithms.git",
+      "state": {
+        "revision": "042e1c4d9d19748c9c228f8d4ebc97bb1e339b0b",
+        "version": "1.0.4"
       }
     },
     {
-      "identity" : "swift-atomics",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-atomics.git",
-      "state" : {
-        "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
-        "version" : "1.3.0"
+      "identity": "swift-atomics",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/apple/swift-atomics.git",
+      "state": {
+        "revision": "b601256eab081c0f92f059e12818ac1d4f178ff7",
+        "version": "1.3.0"
       }
     },
     {
-      "identity" : "swift-certificates",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-certificates.git",
-      "state" : {
-        "revision" : "4b092f15164144c24554e0a75e080a960c5190a6",
-        "version" : "1.14.0"
+      "identity": "swift-certificates",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/apple/swift-certificates.git",
+      "state": {
+        "revision": "4b092f15164144c24554e0a75e080a960c5190a6",
+        "version": "1.14.0"
       }
     },
     {
-      "identity" : "swift-collections",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-collections.git",
-      "state" : {
-        "revision" : "8c0c0a8b49e080e54e5e328cc552821ff07cd341",
-        "version" : "1.2.1"
+      "identity": "swift-collections",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/apple/swift-collections.git",
+      "state": {
+        "revision": "8c0c0a8b49e080e54e5e328cc552821ff07cd341",
+        "version": "1.2.1"
       }
     },
     {
-      "identity" : "swift-crypto",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-crypto.git",
-      "state" : {
-        "revision" : "95ba0316a9b733e92bb6b071255ff46263bbe7dc",
-        "version" : "3.15.1"
+      "identity": "swift-crypto",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/apple/swift-crypto.git",
+      "state": {
+        "revision": "95ba0316a9b733e92bb6b071255ff46263bbe7dc",
+        "version": "3.15.1"
       }
     },
     {
-      "identity" : "swift-http-structured-headers",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-http-structured-headers.git",
-      "state" : {
-        "revision" : "1625f271afb04375bf48737a5572613248d0e7a0",
-        "version" : "1.4.0"
+      "identity": "swift-http-structured-headers",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/apple/swift-http-structured-headers.git",
+      "state": {
+        "revision": "1625f271afb04375bf48737a5572613248d0e7a0",
+        "version": "1.4.0"
       }
     },
     {
-      "identity" : "swift-http-types",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-http-types.git",
-      "state" : {
-        "revision" : "a0a57e949a8903563aba4615869310c0ebf14c03",
-        "version" : "1.4.0"
+      "identity": "swift-http-types",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/apple/swift-http-types.git",
+      "state": {
+        "revision": "a0a57e949a8903563aba4615869310c0ebf14c03",
+        "version": "1.4.0"
       }
     },
     {
-      "identity" : "swift-log",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-log.git",
-      "state" : {
-        "revision" : "ce592ae52f982c847a4efc0dd881cc9eb32d29f2",
-        "version" : "1.6.4"
+      "identity": "swift-log",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/apple/swift-log.git",
+      "state": {
+        "revision": "ce592ae52f982c847a4efc0dd881cc9eb32d29f2",
+        "version": "1.6.4"
       }
     },
     {
-      "identity" : "swift-metrics",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-metrics.git",
-      "state" : {
-        "revision" : "0743a9364382629da3bf5677b46a2c4b1ce5d2a6",
-        "version" : "2.7.1"
+      "identity": "swift-metrics",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/apple/swift-metrics.git",
+      "state": {
+        "revision": "0743a9364382629da3bf5677b46a2c4b1ce5d2a6",
+        "version": "2.7.1"
       }
     },
     {
-      "identity" : "swift-nio",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-nio.git",
-      "state" : {
-        "revision" : "a18bddb0acf7a40d982b2f128ce73ce4ee31f352",
-        "version" : "2.86.2"
+      "identity": "swift-nio",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/apple/swift-nio.git",
+      "state": {
+        "revision": "a18bddb0acf7a40d982b2f128ce73ce4ee31f352",
+        "version": "2.86.2"
       }
     },
     {
-      "identity" : "swift-nio-extras",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-nio-extras.git",
-      "state" : {
-        "revision" : "a55c3dd3a81d035af8a20ce5718889c0dcab073d",
-        "version" : "1.29.0"
+      "identity": "swift-nio-extras",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/apple/swift-nio-extras.git",
+      "state": {
+        "revision": "a55c3dd3a81d035af8a20ce5718889c0dcab073d",
+        "version": "1.29.0"
       }
     },
     {
-      "identity" : "swift-nio-http2",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-nio-http2.git",
-      "state" : {
-        "revision" : "5e9e99ec96c53bc2c18ddd10c1e25a3cd97c55e5",
-        "version" : "1.38.0"
+      "identity": "swift-nio-http2",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/apple/swift-nio-http2.git",
+      "state": {
+        "revision": "5e9e99ec96c53bc2c18ddd10c1e25a3cd97c55e5",
+        "version": "1.38.0"
       }
     },
     {
-      "identity" : "swift-nio-ssl",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-nio-ssl.git",
-      "state" : {
-        "revision" : "b2b043a8810ab6d51b3ff4df17f057d87ef1ec7c",
-        "version" : "2.34.1"
+      "identity": "swift-nio-ssl",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/apple/swift-nio-ssl.git",
+      "state": {
+        "revision": "b2b043a8810ab6d51b3ff4df17f057d87ef1ec7c",
+        "version": "2.34.1"
       }
     },
     {
-      "identity" : "swift-nio-transport-services",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-nio-transport-services.git",
-      "state" : {
-        "revision" : "e645014baea2ec1c2db564410c51a656cf47c923",
-        "version" : "1.25.1"
+      "identity": "swift-nio-transport-services",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/apple/swift-nio-transport-services.git",
+      "state": {
+        "revision": "e645014baea2ec1c2db564410c51a656cf47c923",
+        "version": "1.25.1"
       }
     },
     {
-      "identity" : "swift-numerics",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-numerics.git",
-      "state" : {
-        "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
-        "version" : "1.1.1"
+      "identity": "swift-numerics",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/apple/swift-numerics.git",
+      "state": {
+        "revision": "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
+        "version": "1.1.1"
       }
     },
     {
-      "identity" : "swift-protobuf",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-protobuf.git",
-      "state" : {
-        "revision" : "2547102afd04fe49f1b286090f13ebce07284980",
-        "version" : "1.31.1"
+      "identity": "swift-protobuf",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/apple/swift-protobuf.git",
+      "state": {
+        "revision": "2547102afd04fe49f1b286090f13ebce07284980",
+        "version": "1.31.1"
       }
     },
     {
-      "identity" : "swift-service-lifecycle",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swift-server/swift-service-lifecycle.git",
-      "state" : {
-        "revision" : "e7187309187695115033536e8fc9b2eb87fd956d",
-        "version" : "2.8.0"
+      "identity": "swift-service-lifecycle",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/swift-server/swift-service-lifecycle.git",
+      "state": {
+        "revision": "e7187309187695115033536e8fc9b2eb87fd956d",
+        "version": "2.8.0"
       }
     },
     {
-      "identity" : "swift-system",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-system.git",
-      "state" : {
-        "revision" : "395a77f0aa927f0ff73941d7ac35f2b46d47c9db",
-        "version" : "1.6.3"
+      "identity": "swift-system",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/apple/swift-system.git",
+      "state": {
+        "revision": "395a77f0aa927f0ff73941d7ac35f2b46d47c9db",
+        "version": "1.6.3"
       }
     },
     {
-      "identity" : "thrift-swift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/undefinedlabs/Thrift-Swift",
-      "state" : {
-        "revision" : "18ff09e6b30e589ed38f90a1af23e193b8ecef8e",
-        "version" : "1.1.2"
+      "identity": "thrift-swift",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/undefinedlabs/Thrift-Swift",
+      "state": {
+        "revision": "18ff09e6b30e589ed38f90a1af23e193b8ecef8e",
+        "version": "1.1.2"
       }
     },
     {
-      "identity" : "vibe-notify-macos",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/vibecare-io/vibe-notify-macos.git",
-      "state" : {
-        "revision" : "c74f2acd745eaaa2db31741b33bbcadd6bc3d664",
-        "version" : "0.0.5"
+      "identity": "vibe-notify-macos",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/vibecare-io/vibe-notify-macos.git",
+      "state": {
+        "revision": "b0c7c2167481779eaf201018456ea0da1d73b3e6",
+        "version": "0.0.6"
       }
     }
   ],
-  "version" : 3
+  "version": 3
 }

--- a/clients/macos-swift/VibeCare/vibecareTests/PluginAlertPresentationTests.swift
+++ b/clients/macos-swift/VibeCare/vibecareTests/PluginAlertPresentationTests.swift
@@ -80,6 +80,46 @@ private let defaultBlob = #"""
     #expect(p.blurIntensity == nil)
 }
 
+// MARK: - Task timer
+
+// `NotificationPreferences.taskTimerSeconds`/`taskTimerUnitLabel`/
+// `taskTimerCompletionLabel` are what `VibeNotifyConfig.showNotification`
+// reads to build VibeNotify's `TaskTimer` (the countdown ring) — sourced
+// from an action's `task_timer_seconds` etc. parameters via
+// `ScheduleActionCard`/`NotificationManager`'s deserializers. `nil` (the
+// default) means no task timer at all, which is what keeps every action
+// that predates this field rendering exactly as it did before. Exercised
+// here at the model level — construction, `copy()`, `Equatable`/`Hashable`
+// — since those are the surfaces every caller that builds or compares a
+// `NotificationPreferences` actually goes through.
+@Test func taskTimerFieldsDefaultToNil() {
+    let p = NotificationPreferences.default
+    #expect(p.taskTimerSeconds == nil)
+    #expect(p.taskTimerUnitLabel == nil)
+    #expect(p.taskTimerCompletionLabel == nil)
+}
+
+@Test func taskTimerFieldsSurviveCopy() {
+    let p = NotificationPreferences(
+        taskTimerSeconds: 20,
+        taskTimerUnitLabel: "seconds",
+        taskTimerCompletionLabel: "Break complete"
+    )
+    let copy = p.copy()
+
+    #expect(copy.taskTimerSeconds == 20)
+    #expect(copy.taskTimerUnitLabel == "seconds")
+    #expect(copy.taskTimerCompletionLabel == "Break complete")
+    #expect(copy !== p)
+    #expect(copy == p)
+}
+
+@Test func taskTimerSecondsParticipatesInEquality() {
+    let withTimer = NotificationPreferences(taskTimerSeconds: 20)
+    let withoutTimer = NotificationPreferences(taskTimerSeconds: nil)
+    #expect(withTimer != withoutTimer)
+}
+
 // MARK: - Routing
 
 // An alert with no appearance is untouched by any of this.

--- a/docs/ACTIONS_IMPLEMENTATION.md
+++ b/docs/ACTIONS_IMPLEMENTATION.md
@@ -381,6 +381,12 @@ Section("Actions") {
 
 ## Example Action Configurations
 
+> This document is a build plan from 2025-10-13, not a parameter reference. The
+> current, complete list of `notification` action `parameters` keys — including
+> the break-countdown keys (`task_timer_seconds` and friends) and how they
+> resolve against the user's global notification settings — lives in
+> [`clients/macos-swift/VibeCare/CLAUDE.md`](../clients/macos-swift/VibeCare/CLAUDE.md#action-parameters-keys).
+
 ### Meeting Reminder
 ```json
 {

--- a/docs/superpowers/plans/2026-08-16-vibenotify-rich-renderer.md
+++ b/docs/superpowers/plans/2026-08-16-vibenotify-rich-renderer.md
@@ -193,6 +193,20 @@ Routing rule, in order — rule 3 is why rule 1 exists:
 - [ ] **Step 5:** Verify in-app: a plugin alert renders at its existing geometry; ESC, click-anywhere and a button each dismiss an interrupt; a countdown cancelled by early dismissal does **not** fire afterwards; `PluginInterrupt`'s red flash still works (its 10-arg literal must still compile).
 - [ ] **Step 6:** Commit: `refactor(client): drop the reimplemented plugin alert view`
 
+### Task 13: Webview surface (added mid-run by user; do LAST)
+
+**Not in the approved spec** — added by explicit user request during execution, to be done after Task 12. It overlaps sub-project C, which deferred "embedding the blink-jump game". Needs a short design pass before implementation; the notes below are what execution already knows, not a design.
+
+**Goal:** VibeNotify can render a web page as an alert surface, in both `.interrupt` (full screen) and `.ambient` (popup) modes — e.g. the blink-jump plugin UI at `/p/blink-jump/`, so a 20-20-20 break can *be* the game.
+
+**Known constraints — these are the hard part, not the WKWebView:**
+- Plugin UIs are reverse-proxied by core at `<base_url>/p/<id>/` (`PluginList.base_url` in `proto/client/v1/client.proto`). The port is assigned at runtime, so no URL can be hardcoded.
+- **Authenticated endpoints.** The client's existing `PluginWebView` appends `?vc=<token>` (`PluginList.token`) on the *first* load, and `PluginShellService.resolveIcon` fetches through the proxy with a `vc_session` cookie. A library-level `WKWebView` gets neither for free — it has its own `WKWebsiteDataStore` and cookie jar. Decide deliberately whether the library takes a pre-configured `WKWebView`/`WKWebViewConfiguration` from the caller (keeps all auth in VibeCare, keeps the library generic) or learns about tokens (couples a general-purpose library to VibeCare's auth). **Strong lean: the former** — VibeNotify is published for general use and must not learn what a `vc_session` is.
+- The countdown clock and buttons must still work over the webview; the web content must not swallow ESC or the dismissal hit target.
+- A live web page inside an interrupt is a focus and keyboard-input surface — revisit the "interrupt takes key focus" decision for this case specifically.
+
+**Do not start this before Task 12 is complete and reviewed.**
+
 ---
 
 ## Deferred (do not build here)

--- a/docs/superpowers/plans/2026-08-16-vibenotify-rich-renderer.md
+++ b/docs/superpowers/plans/2026-08-16-vibenotify-rich-renderer.md
@@ -1,0 +1,207 @@
+# VibeNotify Rich Renderer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give VibeNotify one renderer that draws an illustration, buttons and a cancellable countdown, legible over any desktop, and retarget VibeCare's two consuming files at it.
+
+**Architecture:** A third model + renderer (`RichNotification` / `RichNotificationView`) added beside the two existing ones, which do not change. One named `AlertMode` axis (`.interrupt` / `.ambient`) drives backdrop, chrome and legibility together. The dismiss clock moves out of the view bodies into `OverlayWindowManager`, keyed by id, injected via SwiftUI environment so caller-supplied content inherits it.
+
+**Tech Stack:** Swift 6.1, SwiftUI, AppKit, SVGView 1.0.6, swift-testing. macOS 14 floor (library), macOS 15 (client).
+
+**Spec:** `docs/superpowers/specs/2026-08-16-vibenotify-rich-renderer-design.md` — read it alongside this plan; every task argues from it.
+
+## Global Constraints
+
+- **Two repos.** Library: `/Users/thapakazi/repos/thapakazi/vibecare/simple-alerts` (Tasks 1–9). Client: `/Users/thapakazi/repos/thapakazi/vibecare/core` (Tasks 10–12).
+- **Additive only.** No existing type gains/loses a property; no existing function signature changes; both existing renderers stay byte-identical.
+- **`Configuration.init` (`OverlayWindowManager.swift:98-118`): new parameters MUST have defaults and MUST NOT be reordered or renamed.** `PluginInterrupt.swift:90-101` and `PluginAlertOverlay.swift:181-202` are memberwise literals that must keep compiling.
+- **0.55** is the single derived constant: interrupt dim, ambient scrim peak alpha, and the "local scrim redundant" threshold. Derived once (spec §Where 0.55 comes from); never re-derive.
+- Text is light in both modes, both themes: title white semibold, message white 0.9, footnote white 0.6. Shadows **oppose** text colour — title `.black.opacity(0.55)` r6 y1; message/footnote `.black.opacity(0.45)` r4 y1. Never `.clear`.
+- **Decided this session:** interrupt takes keyboard focus. Under Reduce Transparency, ambient draws a solid opaque backdrop behind its text block (only for those users).
+- Commit after every task. Library commits are bisectable; do not batch.
+- To iterate on the library from the client before Task 10's release, run `swift package edit vibe-notify-macos --path ../../../../simple-alerts` from `clients/macos-swift/VibeCare/`. It is a per-developer, uncommitted override — **never commit a path dependency**, since SwiftPM derives identity from the directory basename (`simple-alerts`) and would break `package: "vibe-notify-macos"` at `Package.swift:56`.
+
+---
+
+### Task 1: Make the library's test target compile
+
+**Files:** Modify `simple-alerts/Tests/VibeNotifyTests/VibeNotifyTests.swift:1`; modify `.github/workflows/release.yml:25-28`
+
+- [ ] **Step 1:** Change `import TestingE` → `import Testing`. Replace the empty `example()` with a real assertion (`#expect(ScreenBlurIntensity.medium.radius == 25)`).
+- [ ] **Step 2:** Run `swift test`. Expected: PASS. (Before this change it fails to compile with "no such module 'TestingE'".)
+- [ ] **Step 3:** In `release.yml`, uncomment the test step and make it `swift test` without `|| true` and without `continue-on-error`. Add a `push`/`pull_request` trigger on branches so `main` is validated between releases.
+- [ ] **Step 4:** Commit: `fix(tests): make the test target compile and gate releases on it`
+
+### Task 2: Commit the pending glow fix on its own
+
+**Files:** `simple-alerts/Sources/VibeNotify/Views/SVGNotificationView.swift:37` (already edited in the working tree)
+
+- [ ] **Step 1:** Verify `git diff` shows only white→green on line 37. `changelog/30112025-adaptive-theme-support.md:16` already documents green, so shipped-white is the bug.
+- [ ] **Step 2:** Commit that file alone: `fix(svg): apply the documented green glow in dark mode`
+
+### Task 3: Fix blur-window orphaning (blocker for interrupt)
+
+**Files:** Modify `simple-alerts/Sources/VibeNotify/Core/OverlayWindowManager.swift:190-214`; Test: `Tests/VibeNotifyTests/OverlayLifetimeTests.swift` (new)
+
+Today `dismiss` returns at `guard let window = activeWindows[id]` (`:190-191`) **before** touching `blurWindows[id]`. At 0.1 dim that orphan is a nuisance; at 0.55 it is an inescapable dark sheet over the whole screen.
+
+**Interfaces — Produces:** `dismiss(id:animated:)` tears down blur and main windows independently.
+
+- [ ] **Step 1:** Write a failing test: show with `screenBlur: true`, remove the main window directly from `activeWindows`, call `dismiss(id:)`, assert `blurWindows[id] == nil`.
+- [ ] **Step 2:** Run `swift test`. Expected: FAIL (blur window survives).
+- [ ] **Step 3:** Restructure `dismiss` so blur teardown is keyed on the id independently of the main-window guard. Add a sweep closing any `blurWindows` entry with no matching `activeWindows` entry.
+- [ ] **Step 4:** Run `swift test`. Expected: PASS.
+- [ ] **Step 5:** Commit: `fix(overlay): never orphan a blur window`
+
+### Task 4: `screenDim` parameter, `alwaysOnTop` as floor, Swift 6 warnings
+
+**Files:** Modify `OverlayWindowManager.swift` — `Configuration` (`:77-139`), `createBlurWindow` (`:262-317`, dim pinned at `:289`), level logic (`:251`), `animateDismiss` (`:414-425`); Test: `Tests/VibeNotifyTests/ConfigurationTests.swift` (new)
+
+**Interfaces — Produces:** `Configuration.screenDim: Double` (default `0.1`, clamped `0.1...0.95`), appended last in `init`.
+
+- [ ] **Step 1:** Failing tests: default is `0.1`; `0.0` clamps to `0.1`; `2.0` clamps to `0.95`; `alwaysOnTop: true` with `windowLevel: .screenSaver` yields `.screenSaver`, not `.floating`.
+- [ ] **Step 2:** Run `swift test`. Expected: FAIL.
+- [ ] **Step 3:** Add `screenDim` **as the last init parameter with a default** (Global Constraints). Use it at `:289` in place of the hardcoded `0.1`. Change `:251` so `alwaysOnTop` takes the *higher* of `.floating` and the requested level rather than overriding it. Fix the two concurrency warnings at `:422-423` (capture the completion in a `@MainActor` context; do not call `NSWindow.close()` from a nonisolated sync context).
+- [ ] **Step 4:** Run `swift test` and `swift build`. Expected: PASS, and the two warnings are gone.
+- [ ] **Step 5:** Commit: `feat(overlay): make screen dim a parameter and window level a floor`
+
+### Task 5: `AlertMode` + `Configuration` factories + public stored properties
+
+**Files:** Create `Sources/VibeNotify/Models/AlertMode.swift`; modify `OverlayWindowManager.swift:78-96`; Test: extend `ConfigurationTests.swift`
+
+**Interfaces — Produces:** `public enum AlertMode: Sendable { case interrupt, ambient }`; `Configuration.interrupt(...)` and `Configuration.ambient(...)`; `Configuration`'s stored properties readable.
+
+- [ ] **Step 1:** Failing tests: `.interrupt` factory gives `presentationMode == .fullScreen`, `screenBlur == true`, `screenDim == 0.55`, `position == nil`, `alwaysOnTop == true`, and **takes key focus**; `.ambient` gives `screenBlur == false` and a non-nil position.
+- [ ] **Step 2:** Run `swift test`. Expected: FAIL.
+- [ ] **Step 3:** Add the enum and the two factories. Widen `Configuration`'s stored properties `internal` → `public` (they are all `let`, so no new mutability). Nothing else is widened.
+- [ ] **Step 4:** Run `swift test`. Expected: PASS.
+- [ ] **Step 5:** Commit: `feat(overlay): add AlertMode and configuration factories`
+
+### Task 6: The countdown clock
+
+**Files:** Create `Sources/VibeNotify/Core/NotificationClock.swift`; modify `OverlayWindowManager.swift` (`show` at `:148-187`, `dismiss` at `:190`); Test: `Tests/VibeNotifyTests/NotificationClockTests.swift` (new)
+
+Spec §The clock. Three defects, one cause: a bare `asyncAfter` with no handle living inside the view body.
+
+**Interfaces — Produces:**
+```swift
+@MainActor public final class NotificationClock: ObservableObject {
+  public enum Phase: Sendable { case task, dismissing, finished, cancelled }
+  public private(set) var phase: Phase
+  public var deadline: Date { get }
+  public var remaining: TimeInterval { get }
+  public func completeTask()
+  public func cancel()
+}
+```
+`show(id:configuration:countdown:content:)` gains a `Countdown?` parameter; the manager stores `clocks[id]` and injects the clock into the SwiftUI environment around the hosting view at `:167-169`.
+
+- [ ] **Step 1:** Failing tests: task phase then dismiss phase run **sequentially** (total = `duration + delay`, not `min`); `completeTask()` moves `.task` → `.dismissing`; `cancel()` moves to `.cancelled` and fires no completion; a deadline already in the past at wake yields `.cancelled`, never `.finished`; a stale generation token does **not** dismiss a recycled id.
+- [ ] **Step 2:** Run `swift test`. Expected: FAIL.
+- [ ] **Step 3:** Implement. `deadline` is a wall-clock `Date`, not a duration (sleep safety). Each clock carries a monotonically increasing generation; timer callbacks carry `(id, generation)` and no-op on mismatch. Subscribe to `NSWorkspace.didWakeNotification` to re-evaluate on wake. Cancel the clock **unconditionally at the top of `dismiss`, before** the `activeWindows` guard.
+- [ ] **Step 4:** Run `swift test`. Expected: PASS.
+- [ ] **Step 5:** Commit: `feat(overlay): own the countdown clock in the window manager`
+
+### Task 7: `TaskTimer`, `DismissIndicator`, `AutoDismiss` shim
+
+**Files:** Modify `Sources/VibeNotify/Models/NotificationContent.swift:127-135`; Test: extend `NotificationClockTests.swift`
+
+**Interfaces — Produces:**
+```swift
+public struct TaskTimer: Sendable {
+  public let duration: TimeInterval
+  public let unitLabel: String        // "seconds"
+  public let completionLabel: String  // "Break complete"
+}
+public enum DismissIndicator: Sendable { case none, bar, hairlineRing }
+public struct Countdown: Sendable {          // the pair Task 6's show() takes
+  public let task: TaskTimer?
+  public let autoDismiss: AutoDismiss?
+}
+```
+`AutoDismiss` gains `indicator: DismissIndicator`. `Countdown` is the single value `show(id:configuration:countdown:content:)` accepts; either half may be nil, and both nil means no clock. **Task 6 is written against this type — if the two tasks are done out of order, define `Countdown` first.**
+
+- [ ] **Step 1:** Failing tests: `AutoDismiss(delay:showProgress: true)` maps to `.bar`; `false` maps to `.none`; both existing spellings still compile.
+- [ ] **Step 2:** Run `swift test`. Expected: FAIL.
+- [ ] **Step 3:** Add the types. Keep `init(delay:showProgress:)` (`:131`) and the builder's `autoDismiss(after:showProgress:)` (`API/VibeNotify.swift:467-470`) as `@available(*, deprecated)` shims — the library's own convenience constructors pass `showProgress: true` at `:243`, `:273`, `:288` and must keep compiling.
+- [ ] **Step 4:** Run `swift test`. Expected: PASS.
+- [ ] **Step 5:** Commit: `feat(models): split the countdown into task timer and dismiss indicator`
+
+### Task 8: `RichNotification` + `RichNotificationView`
+
+**Files:** Create `Sources/VibeNotify/Models/RichNotification.swift`, `Sources/VibeNotify/Views/RichNotificationView.swift`, `Sources/VibeNotify/Views/Scrim.swift`, `Sources/VibeNotify/Views/CountdownRing.swift`, `Sources/VibeNotify/Views/RichButtonStyle.swift`; Test: `Tests/VibeNotifyTests/LegibilityTests.swift` (new)
+
+Model sketch: spec lines 177–194. `Illustration` carries its own size per case (`.svg(SVGSource, size:)`, `.image(NSImage, size:)`, `.symbol(String, pointSize:, color:)`).
+
+**Interfaces — Consumes:** `AlertMode` (T5), `NotificationClock` (T6), `TaskTimer`/`DismissIndicator` (T7), `StandardNotification.Button` and `SVGSource` **reused verbatim**.
+
+- [ ] **Step 1:** Failing tests on the pure decision function, not the view: `effectiveDim >= 0.55` → no local scrim; `< 0.55` including `0` → feathered scrim; Reduce Transparency + `.ambient` → solid backdrop; Reduce Transparency + `.interrupt` → opaque black at radius 0; a task timer suppresses the dismiss indicator.
+- [ ] **Step 2:** Run `swift test`. Expected: FAIL.
+- [ ] **Step 3:** Implement. Scrim = radial gradient black `0.55` → `0.0`, reaching **exactly zero inside** the drawn rect; `allowsHitTesting(false)`; behind the text block only. **Forbidden** (each turns it into a card): `RoundedRectangle`, `cornerRadius`, clip shape, `.regularMaterial`, `NSVisualEffectView`, stroke, shadow-on-scrim. Ring: arc is one `withAnimation(.linear(duration: remaining))` on `Shape.trim(to:)` set once per phase; the numeral is a `TimelineView(.periodic(from:by: 1))` scoped to the `Text` alone — not a `Timer` into `@State`, which would re-parse `SVGView` every second. Interrupt carries its own full-bleed transparent hit target (the blur window is occluded by a full-screen content window, so `dismissOnScreenTap` alone does not work). Buttons take taps before that target. Write `RichButtonStyle` chrome-less; do **not** reuse `Primary/Secondary/DestructiveButtonStyle` (`StandardNotificationView.swift:166-194`) — flat accent fills vanish against a blurred light desktop.
+- [ ] **Step 4:** Run `swift test`. Expected: PASS.
+- [ ] **Step 5:** Commit: `feat(rich): add the rich notification model and renderer`
+
+### Task 9: Builder routing, deprecations, demo harness
+
+**Files:** Modify `Sources/VibeNotify/API/VibeNotify.swift` (builder `:373-486`, `show()` `:489-562`, `showSVG` `:76`/`:133`); modify `Models/NotificationContent.swift:154`, `Views/SVGNotificationView.swift:5`; modify `VibeNotifyDemo/Sources/main.swift`; Test: `Tests/VibeNotifyTests/RoutingTests.swift` (new)
+
+**Interfaces — Produces:** builder gains `.illustration(_:)`, `.footnote(_:)`, `.taskTimer(_:)`, `.mode(_:)`, all defaulted.
+
+Routing rule, in order — rule 3 is why rule 1 exists:
+1. Any rich-only field set (`mode`, `taskTimer`, `footnote`, `.image`/`.symbol` illustration) → rich renderer.
+2. Else illustration present **and** `buttons` non-empty → rich renderer. *(the silent-drop bug fix)*
+3. Else exactly 0.0.5 behaviour.
+
+- [ ] **Step 1:** Failing tests: `.svg(...).button(...).show()` routes rich (today it silently discards buttons at `:490`); `.svg(...)` alone with no buttons still routes to the old renderer; `.mode(.interrupt)` routes rich even with no buttons.
+- [ ] **Step 2:** Run `swift test`. Expected: FAIL.
+- [ ] **Step 3:** Implement routing. Add `@available(*, deprecated, message:)` naming `RichNotification` to both `showSVG` overloads, `SVGNotification` and `SVGNotificationView`. **Deprecate, do not assert** — `assertionFailure` compiles away in release and resumes the silent drop.
+- [ ] **Step 4:** Add a demo case rendering each mode over a deliberately hostile backdrop, half-black/half-white split first. This is not a test; it is a repeatable way to look at the thing.
+- [ ] **Step 5:** Run `swift test` and `swift build`. Expected: PASS.
+- [ ] **Step 6:** Commit: `feat(api): route illustration+buttons to the rich renderer`
+
+### Task 10: Release 0.0.6 and point core at it
+
+**Files:** `simple-alerts` tag; modify `core/clients/macos-swift/VibeCare/Package.swift:32`, `Package.resolved:266-272`, `vibecare.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved:266-272`
+
+- [ ] **Step 1:** Merge the library branch to `main`; confirm `swift test` is green on `main`.
+- [ ] **Step 2:** Tag `0.0.6` and push the tag — the workflow triggers only on `*.*.*` tags, so pushing the tag *is* the release.
+- [ ] **Step 3:** In core, bump `from: "0.0.5"` → `"0.0.6"` and re-resolve. **Both** resolved files move in the same commit (two build systems each keep their own; two disagreeing files is a failure this tree has had before).
+- [ ] **Step 4:** `just swift-build`. Expected: builds clean with no client edits yet — proof the change is additive.
+- [ ] **Step 5:** Commit: `build(client): take VibeNotify 0.0.6`
+
+### Task 11: Retarget the schedule path
+
+**Files:** Modify `core/clients/macos-swift/VibeCare/vibecare/Services/VibeNotifyConfiguration.swift:93-154` only
+
+`showScheduleNotification` (`:48-84`) keeps its signature exactly. All change is inside the private `showNotification` funnel that every schedule alert and all three previews pass through.
+
+- [ ] **Step 1:** Add `.mode(...)` to the builder chain at `:121-131`, derived from `prefs.screenBlurEnabled` (`:129`): blur on → `.interrupt`, blur off → `.ambient`. No new persisted key, no migration, no new UI control.
+- [ ] **Step 2:** Map the `else` branch at `:118` (`.icon(.system(defaultSystemIcon))`, what an unconfigured schedule gets) to `Illustration.symbol`. Keep the SVG fork at `:107-119` in shape.
+- [ ] **Step 3:** Leave the five generic helpers (`:164`, `:182`, `:200`, `:226`, `:254`) and `showToast`'s `IconType` leak untouched.
+- [ ] **Step 4:** `just swift-test`. Expected: PASS, no test edits.
+- [ ] **Step 5:** Verify with `just swift-run-app` (**not** `just swift-run` — see `Justfile:1097-1099`; only the Xcode build embeds the Info.plist). Split the desktop black-terminal-left / white-browser-right and fire a schedule notification. Title and message legible over **both** halves in **both** system appearances. Exercise all three preview buttons.
+- [ ] **Step 6:** Commit: `feat(client): render schedule notifications through the rich renderer`
+
+### Task 12: Retarget the plugin alert path
+
+**Files:** Modify `core/clients/macos-swift/VibeCare/vibecare/Views/Plugins/PluginAlertOverlay.swift`
+
+- [ ] **Step 1:** Delete `PluginAlertOverlayView` and `PluginAlertButtonStyle` (`:32-132`), the doc comment at `:8-24` (every item on its list is now false), the 15-argument `Configuration` literal (`:181-202`), and the `asyncAfter` at `:206-211`.
+- [ ] **Step 2:** Keep `PluginAlertPresenter.show`'s six-parameter signature **byte for byte** — that freeze is what leaves `PluginShellService.deliver` (`:104`), its routing (`:156`), `PluginAlertPresentation.route` and `PluginAlertPresentationTests.swift:86-114` untouched. Body becomes: policy guard, builder chain, return id. Use `Illustration.image` — the icon arrives as an already-fetched `NSImage` and must stay that way (`PluginShellService.resolveIcon:207` fetches through core's proxy with a `vc_session` cookie; a URL would re-fetch unauthenticated and fail).
+- [ ] **Step 3:** Keep `fittingHeight` (`:224-231`) and `windowPosition(for:)` (`:233-243`). The former survives because the `appearance` blob is out of scope for A; the latter is the insulation boundary.
+- [ ] **Step 4:** `just swift-test`. Expected: PASS, zero test edits.
+- [ ] **Step 5:** Verify in-app: a plugin alert renders at its existing geometry; ESC, click-anywhere and a button each dismiss an interrupt; a countdown cancelled by early dismissal does **not** fire afterwards; `PluginInterrupt`'s red flash still works (its 10-arg literal must still compile).
+- [ ] **Step 6:** Commit: `refactor(client): drop the reimplemented plugin alert view`
+
+---
+
+## Deferred (do not build here)
+
+Snooze rescheduling and driving the task timer from a schedule (B). The `appearance` blob and per-plugin mode control (C). Recording break outcomes anywhere. Restyling the banner/toast family. Removing the deprecated `showSVG`/`SVGNotification`/`SVGNotificationView` symbols (1.0).
+
+## Open questions carried into implementation
+
+- Completion beat length before a task-timer-only alert dismisses. Proposed 1.5s; user decides on seeing it run.
+- Done-while-running dismisses immediately with an acknowledgement label ("Got it"), not `completionLabel` — a surface claiming a completed break when 18s were skipped is lying. User confirms on seeing it run.
+- Exact CGS minimum background alpha (`OverlayWindowManager.swift:288` says "~0.1" with no measurement). Implementer re-measures on macOS 14 and 15 and adjusts the clamp floor.
+- Whether Xcode honours `swift package edit` (`just swift-run-app` resolves via its own `XCRemoteSwiftPackageReference`). First developer to iterate answers it and records it in the library README.

--- a/docs/superpowers/specs/2026-08-16-vibenotify-rich-renderer-design.md
+++ b/docs/superpowers/specs/2026-08-16-vibenotify-rich-renderer-design.md
@@ -1,0 +1,500 @@
+# VibeNotify rich renderer — design
+
+**Status:** draft for review.
+**Scope:** sub-project A of three. B puts a time offset on the `schedule_actions` join table so one rrule can express T-60s / T / T+20s, and will drive the task timer this spec builds. C builds a full-screen break window hosting the blink-jump plugin and extends the `appearance` blob to describe it. Neither is designed here.
+
+## Decisions
+
+| Decision | Reason |
+| --- | --- |
+| Two alert modes, `.interrupt` and `.ambient`, as one named axis above the existing geometry enum | Geometry, backdrop, chrome, escape routes, countdown role and legibility are only ever correct together; today every caller rediscovers the combination by hand |
+| Never a card or panel | The user rejected it; reference image 2 is chrome-less content floating on a dimmed desktop |
+| Text colour derives from the scrim we drew, never from `colorScheme` | The backdrop is the user's live desktop; the system theme answers a question about the OS, not about the pixels underneath |
+| Screen dim becomes a `Configuration` parameter, default `0.1`, `.interrupt` uses `0.55` | The pinned `0.1` is a CoreGraphics requirement, not a design value; `0.55` is the smallest dim at which white text clears 4.5:1 over *any* desktop |
+| Shadows oppose the text colour; never `.clear`, never the text's own colour | Today light mode gets no shadow and dark mode gets a white halo under white text |
+| A third renderer, `RichNotificationView`, added beside the two existing ones | Retrofitting either means rewriting its body and then flagging the old behaviour back in — two renderers wearing one name |
+| The countdown splits into a task timer and a dismiss indicator | One draining `ProgressView` is being asked to mean both "look away for 20 more seconds" and "this closes soon" |
+| The clock moves out of the view bodies into `OverlayWindowManager` | So it is cancellable, written once, and inherited by caller-supplied content |
+| Ships as VibeNotify **0.0.6** | Everything is additive; pre-1.0 carries no stability promise a bigger bump would honour |
+| Packaging stays a remote `from:` dependency; developers use `swift package edit` | A path dependency's SwiftPM identity is the directory basename, which would break `package: "vibe-notify-macos"` at `Package.swift:56` |
+| The schedule path derives its mode from `prefs.screenBlurEnabled` | That toggle is already the user's way of saying "take over my screen"; no new persisted key, no migration, no new control |
+| No streaks, no history, no persistence of break outcomes | The user reviewed the reference image's stats bar and streak row and declined both |
+
+## Problem
+
+A 20-20-20 eye-break notification renders an eye illustration, a title and a message floating over the blurred desktop. On a split desktop — black terminal left, white browser right — the title and message land over the black half and vanish. The illustration survives because it carries its own glow; the words do not.
+
+The cause is that `SVGNotificationView` derives text colour from the system appearance and from nothing else. `useLightText` is defined as `colorScheme == .dark` (`Sources/VibeNotify/Views/SVGNotificationView.swift:17-20`) and every colour decision branches on that one boolean. In light mode the title draws `.primary` with a shadow that is literally `.clear` (`:46-47`), so dark text sits on whatever is behind it with zero separation. In dark mode it draws white text under a *white* glow (`:47`, `:56`) — a halo, which reinforces the text against dark backdrops and erases it against light ones.
+
+Legibility is a property of the backdrop, and the backdrop is the user's live desktop, which the notification does not own and cannot predict. On a split screen there is no theme-derived colour that works on both halves.
+
+Screen blur cannot rescue it, and it is worth being precise because "blur harder" is the obvious first idea: **a blur preserves local mean luminance.** Blurring a white browser half yields a white half. Radius destroys detail, not light. On top of that, the blur window's dim is pinned at `NSColor.black.withAlphaComponent(0.1)` for every intensity (`Sources/VibeNotify/Core/OverlayWindowManager.swift:289`), with the comment above it recording why: "Window needs sufficient background alpha for blur to be visible (~0.1 minimum)". `ScreenBlurIntensity` changes radius only — 10 / 25 / 50 / clamped (`Models/ScreenBlurIntensity.swift:15-22`).
+
+The hook for the fix was scaffolded and never implemented: `SVGNotificationView` accepts `screenBlurActive` at `:8`, `API/VibeNotify.swift:322-323` faithfully threads `configuration.screenBlur` into it, and the body never reads it.
+
+Fixing legibility alone would not reach the break experience the reference images describe. Three further gaps block it, each in a different layer.
+
+**An illustration and buttons cannot coexist.** `SVGNotification` has no `buttons` property (`Sources/VibeNotify/Models/NotificationContent.swift:154-176`); only `StandardNotification` does (`:14`), and its renderer maps `IconType.svg` and `.url` to `EmptyView()` (`Sources/VibeNotify/Views/StandardNotificationView.swift:104-107`) and pins `IconType.image` to a hardcoded 48×48 (`:103`). Worse, the builder's `show()` forks on `useSVG` (`API/VibeNotify.swift:489-562`, fork at `:490`) and routes to `showSVG(...)`, whose parameter list has no `buttons:` — so `.svg(...).button(...).show()` compiles and silently discards every button, with no assert, warning or diagnostic.
+
+**There is no countdown of any kind.** `AutoDismiss` carries exactly `delay` and `showProgress` (`NotificationContent.swift:127-135`), and `showProgress: true` renders an unlabelled draining linear `ProgressView` — no number, no ring, no remaining-seconds text (`SVGNotificationView.swift:61-65`, duplicated byte-identically at `StandardNotificationView.swift:50-54`).
+
+**Caller-supplied SwiftUI content gets no timer at all.** Both the bar and the dismiss timer live inside the two renderer bodies (`SVGNotificationView.swift:94-106`, `StandardNotificationView.swift:149-161`), not in the window manager, and the timer is a bare `DispatchQueue.main.asyncAfter` with no cancellation handle — so a button tap or ESC does not stop it.
+
+The client has already paid for all of this in duplicated code. `PluginAlertOverlayView` plus its private button style (`clients/macos-swift/VibeCare/vibecare/Views/Plugins/PluginAlertOverlay.swift:32-132`) is a reimplementation of `SVGNotificationView` with a button row, and its doc comment (`:8-24`) is an explicit inventory of what VibeNotify 0.0.5 cannot do. The presenter schedules its own `asyncAfter` (`:209-211`) precisely because caller-supplied views get none. That is the real cost: two divergent break-notification implementations, and only the wrong one is reachable from the schedule path.
+
+## Scope
+
+**In:** the library changes below; retargeting the client files that import VibeNotify; the countdown engine; the dim parameter; the legibility rules; the Done/Snooze/Skip row, completion confirmation and live progress; the test strategy; the `swift package edit` setup; the release path.
+
+**Out:** any change to the `appearance` JSON blob — a hand-maintained cross-language contract spanning `core/sdk/swift/VCPluginSDK/Sources/VCPluginSDK/VCAlertAppearance.swift`, `core/plugins/vibecheck/Sources/VibeCheckKit/AlertPrefsStore.swift` and three byte-exact JSON test literals; any change to `schedule_actions`, the proto, the scheduler or the CLI `--json` contract; streaks, history, or persistence of break outcomes; embedding the blink-jump game.
+
+One renderer must serve both paths. The schedule path (`Services/NotificationManager.swift:41` → `Services/VibeNotifyConfiguration.swift:48`) and the plugin path (`Services/PluginShellService.swift:104`, routed at `:156`) reach two different views today, which is why a schedule notification cannot have buttons and a plugin alert cannot be triggered by an rrule. Retiring `PluginAlertOverlayView` in favour of a library renderer is the concrete success test.
+
+## Alert modes
+
+VibeNotify 0.0.5 has geometry but no presentation *intent*. `OverlayWindowManager.PresentationMode` (`OverlayWindowManager.swift:61-74`) says only where a rectangle lands, and eighteen independent `Configuration` knobs (`:78-96`) must each be set consistently by hand. The client demonstrates the cost twice: `PluginAlertOverlay.swift:181-202` and `PluginInterrupt.swift:90-101` are fifteen- and ten-argument memberwise literals that had to rediscover the same combination of `isTransparent`, `alwaysOnTop`, `backgroundColor: .clear` and "no window material" to get a chrome-less float.
+
+This spec adds one named axis above that machinery.
+
+```swift
+public enum AlertMode: Sendable {
+  case interrupt   // whole screen becomes the scrim
+  case ambient     // positioned window, desktop untouched
+}
+```
+
+It is deliberately not called `PresentationMode`; that name is taken by the geometry enum and the two must stay distinguishable in call sites and diffs. A caller picks a mode and supplies content; it does not set `screenBlur`, `screenDim`, `dismissOnScreenTap`, `windowLevel` or text colours independently. `OverlayWindowManager.show(id:configuration:content:)` (`:148-187`) stays public and unchanged for callers that want the old freedom.
+
+### Scrim is not card
+
+The user asked for a scrim behind the text and rejected the card view. That is a contradiction only if the two words name the same object.
+
+A **card** is bounded: an edge, a corner radius, a fill uniform right up to that edge, usually a drop shadow announcing it as a sheet stacked on the desktop. It declares *this is a separate object in front of your work*. That is image 1, and that is what was rejected.
+
+A **scrim** is unbounded: a luminance gradient with no edge to perceive. It declares nothing; it only says *less light gets through here*. Image 2 is a screen-sized scrim.
+
+The two modes are the same principle at two radii of application. In `.interrupt` the whole screen is the scrim, so there is nothing left to put a local scrim on — a local one there would be a visible rectangle over a uniform field, which is a card arrived at by accident. In `.ambient` a screen-sized scrim is forbidden (dimming the desktop for a toast is a category error), so the scrim is local, and to stay a scrim rather than becoming a card it must feather to zero before its geometry ends.
+
+### `.interrupt`
+
+Used when the alert *is* the task: a scheduled break, a full-attention prompt. Sub-project B's T-0 stage will fire in this mode.
+
+*Geometry.* `.fullScreen` on the target screen, content centred, `position`/`width`/`height` left nil. An explicit position and size override the presentation mode entirely (`createWindow`, `:224-259`, position override at `:236-239`) — that override is what `PluginAlertPresenter` relies on, and interrupt mode must not use it.
+
+*Backdrop.* One blur window per alert id as today (`createBlurWindow`, `:262-317`), with a heavy radius and a dim of 0.55.
+
+*Chrome.* None. `backgroundColor: .clear`, `isTransparent: true`, no `transparentMaterial`, no rounded rectangle, no border, no container shadow because there is no container. Illustration, title, message, ring, button row and footnote sit directly on the scrim in one centred vertical stack.
+
+*Escape.* Three routes, live simultaneously: ESC, a click anywhere, and explicit buttons. ESC already works — `DismissibleWindow.keyDown` traps keyCode 53 (`:8-15`) and `show` wires `onEscapePressed` (`:171-174`).
+
+Click-anywhere does **not** work today in this configuration, and that is a defect to fix rather than inherit. `dismissOnScreenTap` installs its handler on the *blur* window (`:280`, `:293-300`), which is levelled one step below the notification window (`:276-279`). With a content window sized to the alert, clicks outside it fall through and dismiss; with a full-screen content window the blur window is completely occluded and receives nothing. Interrupt mode therefore carries its own full-bleed transparent hit target inside the content view. `dismissOnScreenTap` stays set on the blur window so the two paths agree.
+
+### `.ambient`
+
+Used when the alert is peripheral: confirmations, warnings, plugin notices, toasts. This is what the six builder call sites in `VibeNotifyConfiguration.swift` (`:48`, `:164`, `:182`, `:200`, `:226`, `:254`) map onto.
+
+*Geometry.* A positioned window sized to its content — the shape `PluginAlertPresenter` already produces by hand (`PluginAlertOverlay.swift:181-190`).
+
+*Backdrop.* No blur window at all. `screenBlur: false`; dim does not apply. The desktop keeps its light and every other window stays clickable.
+
+*Chrome.* Still none. The text block alone gets the feathered scrim.
+
+*Escape.* "Click anywhere" is unavailable by construction — there is no global surface, and stealing desktop clicks for a toast is worse than the problem it solves. Ambient dismisses on a click on the alert itself, on ESC while its window is key, on its buttons, and on auto-dismiss expiry.
+
+## Legibility
+
+### The invariant
+
+> Text is never rendered over a backdrop whose luminance we do not control.
+
+Interrupt satisfies it by dimming the entire screen; ambient by placing a local feathered scrim under the text block. Text colour then follows the scrim we drew. `useLightText` and its `@Environment(\.colorScheme)` dependency (`SVGNotificationView.swift:10`, `:17-20`) are deleted outright, as is the clone at `PluginAlertOverlay.swift:48`.
+
+Because both scrims are dark, both modes render light text in both system themes: title pure white semibold; message white at 0.9; footnote white at 0.6. The illustration gets a dark drop shadow, not a glow — `SVGNotificationView.swift:37` currently applies `.green.opacity(0.5)` in dark mode, which is a halo for the same reason the title's is.
+
+### Where 0.55 comes from
+
+Worst case for light text is a pure white desktop. Compositing black at alpha *a* over white leaves sRGB `1 − a`; for white text to clear WCAG AA at 4.5:1 the backdrop's relative luminance must be at most `1.05/4.5 − 0.05 = 0.1833`, which is sRGB ≈ 0.465, i.e. *a* ≈ 0.535. Rounded up, **0.55 is the smallest dim at which white text is guaranteed legible over any desktop whatsoever.** That single number is used three times and derived once: it is the interrupt dim, it is the ambient scrim's peak opacity, and it is the threshold above which a local scrim is redundant.
+
+### Shadows oppose the text
+
+Every text element carries a shadow whose colour is the opposite pole from the text's own. Light text gets a dark shadow; dark text, should any path produce it, gets a light one. Never `.clear`, never the text's own colour.
+
+For the light text above: title `.black.opacity(0.55)`, radius 6, offset y 1; message and footnote `.black.opacity(0.45)`, radius 4, offset y 1. A small positive y offset rather than a symmetric halo — a displaced shadow reads as separation, a centred one reads as glow.
+
+Under the invariant the shadow is a second-order safety net, not the contrast mechanism: it covers the seam where a glyph's antialiased edge meets an unusually bright patch surviving the scrim. It is written as a general opposition rule so it stays correct under any future inversion, and so `StandardNotificationView` — which supplies its own opaque card (`:68-76`) and therefore already controls its backdrop — can adopt it without a special case.
+
+### The feathered scrim (ambient only)
+
+A radial gradient, black, from 0.55 at the centre of the text block to 0.0 at the edge of a rect padded outward well past the text bounds — far enough that the falloff completes before the geometry ends. Nothing else. Explicitly absent, because each of these is what turns it back into a card: no `RoundedRectangle`, no `cornerRadius`, no clip shape; no `.background(.regularMaterial)` or `NSVisualEffectView`; no stroke or hairline; no shadow on the scrim itself.
+
+It is `allowsHitTesting(false)`, and it sits behind the text block only — not behind the illustration, not behind the buttons, which carry their own contrast. For wide, short blocks a vertical linear gradient with the same endpoints is permitted; the constraint is that alpha reaches exactly zero inside the drawn rect, never at its boundary.
+
+### `screenBlurActive` becomes the selector, carrying dim
+
+The stubbed parameter at `SVGNotificationView.swift:8` is the natural place to select between the two strategies — the renderer needs to know whether something else already made the backdrop safe. It cannot stay a boolean over `screenBlur`, because `screenBlur == true` is also true for a `.light` blur at the pinned 0.1, which is not a safe backdrop. The bit that matters is the dim. So the renderer's input becomes the effective backdrop dim:
+
+- dim ≥ 0.55 → a global scrim already exists → draw no local scrim.
+- dim < 0.55, including 0 → draw the feathered scrim.
+
+`init(notification:screenBlurActive:onDismiss:)` (`:22-30`) is retained as a shim mapping `true → 0.1` and `false → 0`, so existing call sites compile and — correctly — now get the feathered scrim they should always have had.
+
+### The dim parameter
+
+Add `screenDim: Double` to `Configuration`, **defaulting to 0.1**. That default reproduces today's rendering byte for byte, so all six adapter call sites and both hand-written literals in the client are unaffected by the addition alone. `.interrupt` sets 0.55. `.ambient` builds no blur window, so the value is inert.
+
+Clamp to `0.1...0.95`. The floor is not 0: with blur enabled, an alpha below the CGS minimum silently stops the blur compositing, so "blur with no dim" is not expressible and a caller who wants an undimmed desktop must turn blur off instead. The ceiling is not 1.0: a fully opaque backdrop is no longer a blur.
+
+**Dim and radius are independent axes and stay independent.** Radius controls how much of the desktop's *detail* survives; dim controls how much of its *light* survives. Heavy blur with no dim is a legitimate privacy screening; light blur with a heavy dim is a legible interrupt that still shows you roughly where your windows are. Folding dim into `ScreenBlurIntensity` would make both inexpressible.
+
+### Accessibility
+
+`PluginInterrupt.swift:75` gates its red flash on `NSWorkspace.shared.accessibilityDisplayShouldReduceMotion`, and it is the only such check in either repository. Both new modes follow that precedent.
+
+*Reduce Motion.* `animatePresentation` goes false, so the window is ordered front at final opacity; the spring entrance (`SVGNotificationView.swift:77`, mirrored at `PluginAlertOverlay.swift:107`) is skipped and content appears at final scale. Ambient additionally drops any slide-in.
+
+The countdown is the deliberate exception: it keeps animating, because it is information the user is reading, not decoration. What changes is cadence — arc and numeral advance in discrete one-second steps instead of a continuous sweep. The existing `withAnimation(.linear(duration: delay))` at `:97` has no step mode and no cancellation handle, which is one more reason the countdown is rebuilt rather than parameterised.
+
+*Reduce Transparency* (`accessibilityDisplayShouldReduceTransparency`, checked nowhere today). Interrupt replaces blur-plus-dim with a solid opaque black backdrop at radius 0; the desktop was already unreadable behind a 0.55 dim and a 50-point blur, so honouring the setting costs nothing.
+
+Ambient is harder, and is an open question below: a feathered scrim *is* a transparency gradient and cannot be made opaque and stay edgeless.
+
+## The rich model and renderer
+
+A third path — `RichNotification` plus `RichNotificationView` — is added alongside `StandardNotificationView` (`StandardNotificationView.swift:4`) and `SVGNotificationView` (`SVGNotificationView.swift:5`). Neither existing renderer changes. Neither existing model changes.
+
+### Why a third renderer and not a retrofit
+
+Retrofitting `SVGNotificationView` means adding buttons, style and an icon concept to `SVGNotification`, which has none of them (`NotificationContent.swift:154-176`: six stored properties). It means adding `buttons:` to both `showSVG` overloads (`API/VibeNotify.swift:76-97`, `:133-154`), each already twenty parameters wide, and threading it through `showSVGNotification` (`:314-331`). And it means rewriting the body anyway: the only button it can draw is a hardcoded `"Dismiss"` behind `interactive == true` (`SVGNotificationView.swift:68-73`), and the legibility rules replace its colour logic wholesale. Nothing of the original would survive but the `SVGView` call — yet every existing caller still depends on the old rendering, so the old behaviour must be preserved behind a flag. A renderer with a "behave like 0.0.5" flag is two renderers wearing one name.
+
+Retrofitting `StandardNotificationView` is worse, because its limitations are load-bearing for the shape it draws: `EmptyView()` for SVG and URL icons (`:104-107`), a hardcoded 48×48 image frame (`:103`), a 48pt font for symbols (`:29`), and an unconditional opaque card (`:68-76`). Undoing the first three means giving `IconType` a size, which changes a public enum every existing caller constructs, including `NotificationManager.swift:92`.
+
+The third renderer touches nothing that ships today. If it is wrong, it is deleted.
+
+### The model
+
+A sketch, not an implementation:
+
+```swift
+public struct RichNotification {
+    public enum Illustration {
+        case svg(SVGSource, size: CGSize)
+        case image(NSImage, size: CGSize)
+        case symbol(String, pointSize: CGFloat, color: Color?)
+    }
+
+    public let illustration: Illustration?
+    public let title: String?
+    public let message: String?
+    public let footnote: String?               // "Press ESC or click anywhere to skip"
+    public let buttons: [StandardNotification.Button]
+    public let taskTimer: TaskTimer?
+    public let autoDismiss: StandardNotification.AutoDismiss?
+    public let mode: AlertMode
+}
+```
+
+Size lives inside each `Illustration` case rather than as a sibling property because an SF Symbol is sized by a point size and a bitmap or SVG by a `CGSize`; one shared `CGSize` would force callers to encode a font size as a square rectangle. This is also the field that makes the illustration arbitrary — the fixed 48×48 is the defect being escaped, and image 2's eye glyph is nothing like 48pt. All three cases have a named consumer: `.image` for `PluginAlertPresenter`, which is handed an already-fetched `NSImage`; `.symbol` for the schedule path's no-SVG fallback at `VibeNotifyConfiguration.swift:118`; `.svg` for everything else.
+
+`footnote` is a fifth text slot and exists only because image 2 has one: the small line pinned below the ring. It is separate from `message` because it styles differently and because in `.ambient` it is usually absent.
+
+`mode` sits on the model, not only on the window `Configuration`, because the renderer must read it to choose between the two legibility strategies. The presenter derives the `Configuration` from the mode so the two cannot disagree.
+
+### What is reused verbatim
+
+`StandardNotification.Button` (`NotificationContent.swift:69-86`) is used unchanged: already public, already `Identifiable` via `let id = UUID()`, and already carrying the three-case `ButtonStyle` a Done / Snooze / Skip row needs. Inventing a parallel type would fork the type the client's own `NotificationAction` (`NotificationManager.swift:10-13`) bridges to.
+
+`SVGSource` (`:139-151`) already covers file paths and remote URLs, so `Illustration.svg` takes it directly.
+
+`OverlayWindowManager.show(id:configuration:content:)` (`:148-187`) and `dismiss(id:animated:)` (`:190-214`) are already public and sufficient — the client proves it (`PluginAlertOverlay.swift:204`). The rich path is one more caller.
+
+Deliberately *not* reused: `PrimaryButtonStyle`, `SecondaryButtonStyle` and `DestructiveButtonStyle` (`StandardNotificationView.swift:166-194`). They are card chrome — a flat accent fill that vanishes against a blurred light desktop. The client hit exactly this and wrote its own material-backed style with a comment saying so (`PluginAlertOverlay.swift:117-132`). The rich renderer needs its own chrome-less button style, in the library, and shipping it is what lets that private style be deleted.
+
+### One access widening
+
+`Configuration`'s stored properties (`OverlayWindowManager.swift:78-96`) go `internal` → `public`. They are currently write-only from outside the module: the public init (`:98-118`) lets a caller build one and nothing lets a caller read one back. That is exactly why the client hand-writes two full literals instead of taking a base and adjusting one field. Public reads, plus named factory helpers (`Configuration.interrupt(...)`, `Configuration.ambient(...)`), are the precondition for replacing both literals with derive-and-adjust. All the properties are `let`, so no new mutability is exposed; the cost is semver surface, accepted because the client already depends on these names positionally.
+
+No other member is widened. Every other candidate considered had no named caller in this work.
+
+### Builder routing, and the silent button drop
+
+The builder gains `.illustration(_:)` (with `.svg`/`.svgURL` kept as-is), `.footnote(_:)`, `.taskTimer(…)` and `.mode(_:)`, all additive with defaults.
+
+The important change is in `show()` (`API/VibeNotify.swift:489-562`). The routing rule, in order:
+
+1. If any rich-only field is set — `mode`, `taskTimer`, `footnote`, or an `.image`/`.symbol` illustration — route to the rich renderer.
+2. Otherwise, if an illustration is present **and** `buttons` is non-empty, route to the rich renderer. This is the bug fix: `self.buttons` (`:348`, populated by `.button(_:)` at `:388-391`) is honoured instead of dropped.
+3. Otherwise, behave exactly as 0.0.5 does.
+
+Rule 3 is why rule 1 exists. The bug that started this arrives through `VibeNotifyConfiguration.showNotification` (`:93-154`), which sets `.svg(...)` or `.svgURL(...)` (`:110`, `:115`) and never calls `.button(...)`. Under rule 2 alone that call would stay on the old renderer and stay broken. The client fixes it by adding one `.mode(...)` call — a deliberate opt-in, so third-party callers asking for an SVG and nothing else keep the pixels they have today.
+
+On the old path: **deprecate, do not assert.** Add `@available(*, deprecated, message:)` to both `showSVG` overloads (`:76`, `:133`), to `SVGNotification` (`NotificationContent.swift:154`) and to `SVGNotificationView` (`:5`), naming `RichNotification` as the replacement, in the same release. An `assertionFailure` fires at show time on a user's machine and compiles away in release builds, resuming the silent drop. More decisively, after rule 2 there is nothing left to assert on: direct callers of `showSVG` cannot lose buttons because the signature has no `buttons:` parameter, and `SVGNotification` cannot carry buttons because it has no such property. Removal of the deprecated symbols is a 1.0 concern.
+
+### Compatibility
+
+Additive. New type, new view, new builder methods defaulting to 0.0.5 behaviour, one access widening, and one new `Configuration` field whose default reproduces today's 10% dim. No existing type gains or loses a property; no existing function signature changes; both existing renderers are byte-identical. Every current call site in this tree keeps compiling and rendering what it renders now.
+
+The one behavioural change is `.svg(...).button(...).show()`, which stops producing a buttonless notification. That is a bug fix, and it has zero call sites in this repository.
+
+## Countdown
+
+Today's single draining bar is asked to mean two things at once, which is why it means neither. A countdown that measures *the exercise* and one that measures *how long this window stays up* are not the same clock, do not have the same visual weight, and do not end the same way.
+
+### Two types
+
+**`TaskTimer`** is the large tick-marked ring from image 2: a numeric seconds count, a unit label under it, a draining arc. It counts what the user was asked to do, and after the illustration it is the largest element on the surface.
+
+```swift
+public struct TaskTimer: Sendable {
+    public let duration: TimeInterval
+    public let unitLabel: String          // "seconds" — the caller's word
+    public let completionLabel: String    // shown at zero, e.g. "Break complete"
+}
+```
+
+**`DismissIndicator`** is the generic "this closes in N". No number, no label; a thin draining bar or a hairline ring at the edge of the content, deliberately quiet, because nobody needs to watch a toast expire — they need to be able to tell that it will. It replaces the `showProgress: Bool` flag:
+
+```swift
+public enum DismissIndicator: Sendable { case none, bar, hairlineRing }
+public struct AutoDismiss {
+    public let delay: TimeInterval
+    public let indicator: DismissIndicator
+}
+```
+
+`init(delay:showProgress:)` (`NotificationContent.swift:131`) and the builder's `autoDismiss(after:showProgress:)` (`API/VibeNotify.swift:467-470`) stay as deprecated shims mapping `true → .bar`, `false → .none`. The library's own convenience constructors pass `showProgress: true` unconditionally (`:243`, `:273`, `:288`), as do five of the six client call sites; all of them keep compiling.
+
+A task timer renders when and only when the alert declares one — never inferred from `autoDismiss`. A dismiss indicator renders when auto-dismiss is configured with a non-`.none` indicator *and* no task timer is running. Two clocks counting on the same surface is the failure this split exists to prevent.
+
+`.ambient` gets the dismiss indicator only. A labelled ring reads as a task, and in ambient mode there is no task — the number would answer a question the user did not ask.
+
+### When both are set
+
+`.taskTimer(20)` and `.autoDismiss(after: 5)` are not a conflict to arbitrate. They are two sequential phases: **the task timer runs first and alone; the auto-dismiss clock is armed the moment the task reaches zero, and its delay is measured from that moment.** Total on-screen time is `duration + delay`, bounded and predictable. During the task phase no dismiss indicator is drawn.
+
+Earliest-deadline-wins was considered and rejected: it lets the shorter number silently destroy the longer one, so a caller who set a 5-second ceiling out of habit would kill a 20-second eye break at second five and never learn why.
+
+When a task timer is present and no auto-dismiss is set, reaching zero dismisses the alert after holding the completion state for a short beat.
+
+### The clock
+
+Three defects share one cause: the timer is a bare `asyncAfter` with no cancellation handle living inside the view body, so it cannot be stopped from outside, it had to be written twice, and caller-supplied content gets none.
+
+Move it into `OverlayWindowManager`, beside the two dictionaries it already keeps. The manager is already the right owner: it creates the window, owns the ESC handler (`:172`) and the tap-to-dismiss wiring (`:280`, `:296`, `:308`), and holds `activeWindows[id]` and `blurWindows[id]`. A clock is one more thing keyed by the same id.
+
+```swift
+@MainActor public final class NotificationClock: ObservableObject {
+    public enum Phase: Sendable { case task, dismissing, finished, cancelled }
+    public private(set) var phase: Phase
+    public var deadline: Date { get }        // wall clock, not a duration
+    public var remaining: TimeInterval { get }
+    public func completeTask()               // "Done" — end the task phase now
+    public func cancel()                     // Skip / ESC / click-away
+}
+```
+
+`show(id:configuration:countdown:content:)` gains a `Countdown?` parameter. The manager builds the clock, stores it in `clocks[id]`, and injects it into the SwiftUI environment around the hosting view at `:167-169`. That injection is the whole point: the built-in renderers read it from the environment, and so does any caller-supplied content — which is how the fourth problem disappears without those callers asking for anything.
+
+**Cancellation is the window's job, not the view's.** Every dismissal path already funnels into `dismiss(id:animated:)`: buttons call `onDismiss()`, which for built-in notifications is `VibeNotify.dismiss(id:)` (`API/VibeNotify.swift:305`, `:326`); ESC calls it directly (`OverlayWindowManager.swift:173`); a screen tap calls it (`:298`). Cancelling the clock inside `dismiss` fixes button-tap and ESC cancellation in one place.
+
+Cancel it **unconditionally at the top of `dismiss`, before** the `guard let window = activeWindows[id]` at `:191`. That guard is already why an early-removed main window orphans its blur window; a clock behind the same guard would be a live timer with no window.
+
+**Recycled ids.** Id reuse is a real pattern here — `PluginInterrupt.swift:80-82` tracks an `activeFlashID` and dismisses the previous one before showing the next. Today a stale `asyncAfter` from run *N* captures that id and can close run *N+1*'s window. Give each clock a monotonically increasing generation token; the manager's timer callback carries `(id, generation)` and no-ops on mismatch. Public `dismiss(id:)` keeps its current meaning.
+
+**Pause on hover.** The task timer must *not* pause on hover. The exercise is *look twenty feet away*; the user is by definition not watching the pointer, and in `.interrupt` the window covers the screen so the cursor is over it whether or not anyone is there — a hover pause would leave the break open forever. The dismiss indicator *should* pause on hover, but only in `.ambient`: reaching for a button on a draining toast and having it vanish mid-reach is the oldest complaint in this category.
+
+**Sleep and wake.** This is why `deadline` is a `Date` and not a duration: `asyncAfter` across a system sleep is not a contract worth relying on; comparing `Date.now` to a stored deadline is. Subscribe to `NSWorkspace.didWakeNotification` to force re-evaluation on wake rather than waiting for the next tick. A task timer whose deadline passed while the machine slept is **cancelled silently** — no completion state, because the user did not do the exercise, and claiming otherwise is the surface lying.
+
+**Animation without waking the CPU every frame.** Split by what changes. The *arc* is one `withAnimation(.linear(duration: remaining))` on a `Shape.trim(to:)`, set once when the phase starts; Core Animation interpolates it and SwiftUI never re-evaluates the body. This is mechanically what the existing bar already does (`SVGNotificationView.swift:95-98`) — the animation was never the bug, the missing cancellation handle was. Interrupting it with a zero-duration `withAnimation` snaps it to a known value, which is what makes pause/resume and the early-Done snap expressible at all.
+
+The *number* changes once per second, so drive it with `TimelineView(.periodic(from:by: 1))` scoped to the `Text` alone. Not a `Timer` publisher into `@State`: that invalidates the whole notification body once a second — including `SVGView`, whose re-parse is not free — and drifts against wall clock, so the digit and the deadline would eventually disagree. Under Reduce Motion, step the arc once a second inside the same `TimelineView`. Never remove the number.
+
+## Feedback: buttons, progress, confirmation
+
+These are the three things the user named, so they get specified rather than implied.
+
+### Done / Snooze / Skip
+
+The row is `[StandardNotification.Button]` on `RichNotification`, drawn horizontally below the ring and above the footnote, in the caller's order. The library supplies the semantics of *dismissal*; the caller supplies the semantics of *meaning*. Concretely, each button's closure is the caller's, and the library guarantees what happens to the clock and the window around it:
+
+| Button | Style | Clock | Surface |
+| --- | --- | --- | --- |
+| Done | `.primary` | `completeTask()` — ends the task phase now | Acknowledgement state, then dismiss |
+| Snooze | `.secondary` | `cancel()` | No completion state; immediate fade |
+| Skip | `.secondary` | `cancel()` | No completion state; immediate fade |
+
+The existing rule from `StandardNotificationView` is inherited: run `button.action()`, then `onDismiss()` unconditionally (`:114-117`, `:125-128`, `:136-139`). The client's reimplementation independently arrived at the same rule with the same reasoning (`PluginAlertOverlay.swift:80-87`). A Snooze that leaves the interrupt on screen is not a snooze, and a plugin's "Turn off" must take the alert down without the caller needing the window id.
+
+Snooze *rescheduling* is not in A. A has no schedule model and no offset column; the button's closure is whatever the caller passes, and for the schedule path that closure is B's to write. What A owns is that pressing it cancels the clock and closes the window cleanly, and that the surface never claims a break was completed.
+
+Buttons take their taps before the full-bleed dismissal hit target, exactly as `PluginAlertOverlay.swift:101-105` already documents for its own layout.
+
+### Live progress during the break
+
+The task timer *is* the live progress; there is no second progress element. During the task phase the surface shows, top to bottom: illustration, title, message, the ring, the button row, the footnote. The ring shows the numeral (updated once per second by the `TimelineView`), the unit label beneath it, and the draining tick-marked arc. Nothing else moves.
+
+The dismiss indicator is explicitly suppressed while a task timer is running. There is exactly one number on screen at a time, and it is the one the user is meant to obey.
+
+### Completion confirmation
+
+**Reaching zero.** The arc closes, the numeral is replaced by a check glyph and the timer's `completionLabel` ("Break complete"), and the ring stroke shifts to the success colour. Then the dismiss phase runs — its indicator visible if one was configured — and the window fades on its own.
+
+In `.interrupt` there is no separate confirmation surface. The screen dim releasing and the desktop coming back into focus *is* the confirmation; a second "well done" panel after that is one modal too many.
+
+**Pressing Done early.** `completeTask()` ends the task phase immediately and the arc **snaps** to full rather than animating there — a fast fill reads as "the timer sped up", which is confusing about what just happened. The label distinguishes the two honestly: reaching zero shows `completionLabel`; Done at second three shows an acknowledgement ("Got it") and nothing claiming a completed break. The user asked for confirmation that a break *completed*; a surface saying so when eighteen seconds were skipped is telling them something false.
+
+**Cancellation** — Skip, Snooze, ESC, click-away — produces no completion state and no acknowledgement.
+
+The clock exposes its terminal `Phase` to the caller's button closure so the caller can report an outcome, but the alert writes nothing anywhere. The completion state lives for the length of the dismiss phase and dies with the window. Where that outcome goes, if anywhere, is B's.
+
+## Client migration
+
+Four files import VibeNotify and only two change. That is the payoff from insulation that already exists: `NotificationPosition`, `BlurIntensity`, `NotificationPriority` and `NotificationAction` are VibeCare's own types, translated at exactly three boundaries — `BlurIntensity.vibeNotifyIntensity` (`VibeNotifyConfiguration.swift:7-16`), `PluginAlertPresenter.windowPosition(for:)` (`PluginAlertOverlay.swift:233-243`), and the position switch at `VibeNotifyConfiguration.swift:133-144`. Everything upstream talks only in VibeCare types and cannot tell which renderer drew the alert.
+
+So the blast radius is two edited files. Zero files change under `core/plugins/`, `core/sdk/`, `backend/`, `proto/` or `clients/cli/`; zero test files change; zero of the three schedule preview call sites change.
+
+### `Services/VibeNotifyConfiguration.swift`
+
+`showScheduleNotification` (`:48-84`) keeps its signature exactly. All the change is inside the private `showNotification` (`:93-154`), the single funnel every schedule alert and every preview passes through.
+
+The illustration fork at `:107-119` keeps its shape and changes destination: once `show()` stops forking on `useSVG`, the same fork feeds the rich renderer and buttons survive. The `else` branch at `:118` — `.icon(.system(defaultSystemIcon))` for a preference with no configured SVG — must keep producing a legible alert, because it is what an unconfigured schedule gets and it is the case most likely to be overlooked while everyone tests with an eye illustration. It maps to `Illustration.symbol`.
+
+The builder chain at `:121-131` gains one line: `.mode(...)`, derived from `prefs.screenBlurEnabled` (`:129`). Blur enabled means `.interrupt`, blur disabled means `.ambient`. That toggle is already the user's way of saying "take over my screen for this", so it needs no new persisted key, no migration of saved actions, and no new control in the customization UI. The visible consequence for anyone who already has blur on is a real 0.55 dim and light text instead of the pinned 0.1 — the bug fix landing, not a regression.
+
+`.autoDismiss(after:)` at `:127` stays as the dismiss path for schedule alerts in A. The task timer is not wired here, because nothing in A knows how long an exercise lasts. What A must guarantee is that when B supplies a task duration through this same function, `showNotification` passes one clock or the other and never lets a second compete with `:127`.
+
+The five generic helpers (`:164`, `:182`, `:200`, `:226`, `:254`) are untouched. They draw banners and toasts on the standard renderer with an opaque card behind them (`transparent(true, material: .hudWindow)`), and the card is not the bug — the rejection was aimed at the break alert. Restyling the banner family is a separate decision.
+
+`showToast(message:icon:)` at `:254` keeps leaking `StandardNotification.IconType`. Leave it: one parameter, one function, one caller (`NotificationManager.swift:89-105`, building the enum at `:92`). Replacing it costs a new VibeCare-owned icon enum plus a mapping in a file A otherwise never opens, to fix a leak that has never caused a break. The condition that flips this is precise: if the library deletes or renames `StandardNotification.IconType`, the enum work becomes mandatory and moves into A.
+
+### `Views/Plugins/PluginAlertOverlay.swift`
+
+The doc comment at `:8-24` is a list of things VibeNotify 0.0.5 cannot do. Every item on it is removed by this spec, so the view that exists because of the list goes with it.
+
+`PluginAlertOverlayView` and `PluginAlertButtonStyle` (`:32-132`) are deleted. The view's theme-from-system logic (`:48`) is the same bug as `SVGNotificationView.swift:17-20`, faithfully copied — including white-glow-under-white-text at `:57`, `:65`, `:73` and the `.clear` shadow in light mode at `:65`, `:73`. Deleting it is how the plugin path *inherits* the contrast-correct shadows and the feathered scrim rather than needing them ported.
+
+`PluginAlertPresenter.show` (`:157-164`) keeps its six-parameter signature byte for byte. That freeze is what lets `PluginShellService.deliver(_:)` (`:104`) and its routing (`:156`) stay untouched, along with `PluginAlertPresentation.route` (`Models/PluginAlertPresentation.swift:77`) and the tests that lock it (`vibecareTests/PluginAlertPresentationTests.swift:86-114`). Inside, the body becomes: policy guard, builder chain, return the id.
+
+The fifteen-argument `Configuration` literal at `:181-202` is deleted, not maintained. The presenter only reached past the builder because `showCustom` (`API/VibeNotify.swift:190-196`) hardcodes away `screenBlur`, `position` and `width`/`height` — the three things the alert needs, as its own comment at `:138-148` explains. A builder that can express illustration, buttons, blur, dim, position and size removes the reason to hand-write a `Configuration`.
+
+The `asyncAfter` auto-dismiss at `:206-211` goes too; it exists solely because "a caller-supplied view gets none" (`:150-151`), and the countdown engine now owns that lifetime — cancellably, which the `asyncAfter` never was.
+
+`fittingHeight` (`:224-231`) **survives**, and its reason is not the same as the others': the `appearance` blob was authored for an alert with no buttons, and that blob is out of scope for A, so the authored height stays a floor and the measured height wins.
+
+`windowPosition(for:)` (`:233-243`) survives unchanged. It is the insulation boundary, and boundaries are supposed to survive renderer swaps.
+
+The icon reaching the presenter is an already-fetched `NSImage`, not a path, and must stay that way: `PluginShellService.resolveIcon` (`:207`) fetches through core's reverse proxy with a `vc_session` cookie (`:232-234`) under a 2-second bound (`:196`) into a bounded cache. Handing VibeNotify a URL would re-fetch unauthenticated and fail. Hence `Illustration.image`.
+
+### `PluginInterrupt.swift` and `NotificationManager.swift` — untouched
+
+`PluginInterrupt` draws a red rectangle for 450 ms. It has no text, no buttons and no timer, and gains nothing from the new renderer. Its ten-argument `Configuration` literal (`:90-101`) therefore has to keep compiling, and that is a constraint A places on the library: the public init (`OverlayWindowManager.swift:98-118`) may gain parameters — the dim among them — but **every new parameter must have a default and no existing parameter may be reordered or renamed.** Swift matches supplied arguments against declaration order, so inserting a defaulted parameter is safe while reordering two existing ones breaks silently at the type checker.
+
+`NotificationManager` changes not at all. `showScheduleNotification` (`:32-55`) and `executeAction` (`:119-147`) pass preferences straight through, and `deserializeNotificationPreferences` (`:152-189`) reads only keys that already exist.
+
+### The three preview buttons are the acceptance surface
+
+`NotificationCustomizationView.swift:625`, `ActionCardView.swift:863` and `ActionEditSheet.swift:233` all call `showScheduleNotification` with live, unsaved preferences. Because they share the one funnel, they preview the new rendering for free — and that must stay true. **Do not add a preview flag, a preview-only renderer, or a stubbed timer.** A preview that renders through a different path teaches the user a layout they will not get.
+
+Three specifics follow. A preview whose preferences have blur enabled now takes over the whole screen while the user sits in a settings sheet, so ESC and click-anywhere are not decoration — they are the only way out. `NotificationCustomizationView.swift:619-623` substitutes a multi-line options summary into `message` when none is set, which makes the preview the worst case for the ambient feathered scrim: several lines of varying width over an arbitrary desktop, so that is where the scrim gets judged. And the in-sheet confirmation chip that `ActionCardView.swift:836-845` clears after two seconds is unrelated to the alert's own lifetime and stays as it is.
+
+### Policy gating stays where it is
+
+Seven call sites guard on `NotificationPolicy.shared.isNotificationAllowed(priority:)`: six in `VibeNotifyConfiguration.swift` (`:100`, `:165`, `:183`, `:206`, `:232`, `:255`) and one at `PluginAlertOverlay.swift:165`. All seven stay in VibeCare, above the builder. VibeNotify is published from a separate repo for general use; a mute switch buried inside it would be invisible to any other consumer. The guards return `nil` rather than a dead id, which is how callers distinguish "suppressed" from "shown" (`NotificationManager.swift:49-53`).
+
+`PluginInterrupt.fire` (`:47-51`) consults `PluginInterruptPolicy` and nothing else, deliberately (`:16-21`). That exemption is load-bearing in a test — `vibecareTests/PluginInterruptPolicyTests.swift:45` flips `NotificationPolicy.shared` and asserts `shouldInterrupt` does not care. Since `PluginInterrupt.swift` is not edited, it survives by construction.
+
+## Development setup
+
+The committed manifest does not change. `clients/macos-swift/VibeCare/Package.swift:32` keeps `.package(url: "https://github.com/vibecare-io/vibe-notify-macos.git", from: "0.0.5")`, and `vibecare.xcodeproj/project.pbxproj:670-672` keeps its `XCRemoteSwiftPackageReference`. Live iteration is a per-developer, uncommitted override:
+
+```
+swift package edit vibe-notify-macos --path ../../../../simple-alerts
+```
+
+run from `clients/macos-swift/VibeCare/`. SwiftPM drops a symlink at `Packages/vibe-notify-macos` and records the override in `.build/workspace-state.json`; `just swift-build`, `just swift-run` and `just swift-test` then compile the sibling checkout directly, with no tagging and no `Package.resolved` churn.
+
+**Why not a committed path dependency.** SwiftPM derives a path dependency's identity from the *directory basename*. The local checkout lives in a directory called `simple-alerts`, while the product is consumed at `Package.swift:56` as `.product(name: "VibeNotify", package: "vibe-notify-macos")` — `package:` is the identity, and under a path dependency it would become `simple-alerts`. Every product reference would have to change, the Xcode remote package reference would have to be torn out, and both reverted before release. `swift package edit` overrides *resolution* and leaves identity alone.
+
+**Confirming and undoing.** `swift package show-dependencies` prints resolved locations; `ls -l Packages/` shows the symlink. Undo with `swift package unedit vibe-notify-macos` before any commit touching the Swift package, because `Packages/` is not in core's `.gitignore` — it ignores `**/.build` (`:47`), `clients/macos-swift/.build/` (`:56`), `/clients/macos-swift/VibeCare/.build/` (`:136`) and `/clients/macos-swift/VibeCare/.swiftpm/` (`:137`), and nothing else SwiftPM-related. Given that this tree is routinely worked by two concurrent sessions, a stray `git add -A` would commit a symlink to a path that exists on one machine. Add `clients/macos-swift/VibeCare/Packages/` to `.gitignore` as part of this work rather than relying on discipline.
+
+Incidentally: `simple-alerts`'s only remote, `github`, still points at the pre-rename `git@github.com:vibecare-io/macos-notify.git`. It works through GitHub's redirect, but the redirect is a courtesy, not a contract. One line, once: `git remote set-url github git@github.com:vibecare-io/vibe-notify-macos.git`.
+
+## Testing
+
+### Make the test target compile first
+
+`Tests/VibeNotifyTests/VibeNotifyTests.swift:1` reads `import TestingE` — a typo for `import Testing` — so the target does not build and `swift test` fails with "no such module 'TestingE'". The sole `@Test func example()` has an empty body. The release workflow has the test step commented out (`.github/workflows/release.yml:25-28`, "we don't have test for now"), which is why a one-character typo has survived five tags.
+
+Fix the import and delete the empty example as its own commit, before any renderer work. Then uncomment the test step and — more importantly — add a `push: branches: [main]` trigger running `swift build` and `swift test`. Today the workflow triggers only on tags matching `*.*.*` (`:3-6`), so nothing validates `main` between releases. Without this, every assertion below is theatre.
+
+### What is testable without a screen
+
+**The countdown state machine**, and this is the reason it must leave the views. Today's mechanism is untestable by construction: the animation *is* the timer. Replace it with a value that owns remaining time and is advanced by an injected clock, then assert: it counts down and reaches zero; the completion fires exactly once; `cancel()` before zero fires nothing; an early dismissal cancels rather than letting a dead timer fire against a closed window; a task timer with no auto-dismiss dismisses at zero; a task timer *with* one does not dismiss twice. The "fires nothing after cancel" case is the current bug, and it is invisible on screen because the window is already gone.
+
+**The mode and legibility decision**, as a pure function from `(mode, dim)` to text colour, shadow colour, shadow radius and scrim opacity. Assert `.interrupt` yields light text for both colour schemes — that single assertion is the regression guard for `SVGNotificationView.swift:17-20`. Assert the shadow always opposes the text colour and is never `.clear`, which kills `:47` and `:56` permanently. Assert `.interrupt` produces 0.55 and `.ambient` produces none, so nobody re-pins it to the 0.1 at `OverlayWindowManager.swift:289`.
+
+**Builder routing.** Testing this requires splitting `show()` into a pure step that resolves the builder into a content value and an impure step that hands it to the window manager. That split is the highest-leverage testability change in this work; without it, "buttons are no longer dropped" is only assertable by looking at a notification. With it: build an SVG notification with two buttons, assert the resolved content carries both; and the inverse, a standard notification with an SVG icon must no longer resolve to `EmptyView()`.
+
+**Geometry mapping.** Mode plus position plus size resolved to a window frame, as a value. The repo has the precedent and says so: `vibecareTests/PluginAlertPresentationTests.swift:12-19` exists to assert the parts of "does the alert look right" that can be asserted without a screen.
+
+### Core-side
+
+Retargeting must not regress `PluginAlertPresentationTests`, which pins the plugin-alert geometry — 450×220 window, 220×150 illustration, 20s auto-dismiss (`Models/PluginAlertPresentation.swift:47-50`) — and its routing cases (`:86-114`). Extend it with the new mode mapping rather than writing a parallel file. Gotcha: core's test target enumerates its sources explicitly (`clients/macos-swift/VibeCare/Package.swift:77-82`), so a new test file is invisible to `swift test` until added to that list; the comment there records that `swift test` once reported "no tests found" for exactly this class of reason.
+
+### What only an eye can check
+
+Whether text is genuinely readable over an arbitrary desktop; whether the ambient scrim's edge is actually invisible; whether the radius looks right; animation timing. Cover them with a demo harness — an executable target in the library rendering each mode over deliberately hostile backdrops, the half-black/half-white split first among them — and attach screenshots to the pull request. The harness is not a test; it is a repeatable way to look at the thing.
+
+## Risks
+
+**The private CoreGraphics dependency.** `Core/WindowBlurHelper.swift:6-14` declares `CGSDefaultConnectionForThread` and `CGSSetWindowBackgroundBlurRadius` via `@_silgen_name`. Interrupt mode leans on it harder than anything today. For direct distribution it is fine — the file's own comment names WezTerm and Kitty as precedent. For the App Store it is a review risk, and `@_silgen_name` does not change that: it bypasses the public linker symbol table, which makes static detection harder but not impossible. Across OS upgrades it is fragile in a specific way: because the symbol binds at load time, a *removed* symbol is a dyld launch failure for the whole app, not a silently skipped blur.
+
+The mitigation is architectural, not defensive: **make interrupt mode's legibility depend on the dim, not the blur.** The dim is `NSColor.black.withAlphaComponent(...)`, entirely public API. If the blur degrades to nothing, an interrupt over a 0.55 black dim is still legible and still reads as an interrupt; it just looks flatter. That reduces the private call from load-bearing to cosmetic. The `NSVisualEffectView` fallback is noted below as an open question rather than built in A.
+
+**The orphaned blur window is now a bricked desktop.** `dismiss(id:animated:)` opens with `guard let window = activeWindows[id] else { return }` (`:190-191`) and only reaches `blurWindows[id]` after that guard passes. If the main window was already removed by any other path, the full-screen blur window survives with no owner and no route to close it. Today that is a 10% nuisance; under interrupt it is a dark, click-hostile sheet over the entire screen. This is the highest-severity item here and it must be fixed *before* interrupt ships: tear down blur and main windows independently, each keyed on the id, plus a sweep closing any blur window with no matching `activeWindows` entry.
+
+**`alwaysOnTop` swallows `windowLevel`.** `:251` reads `window.level = configuration.alwaysOnTop ? .floating : configuration.windowLevel.nsWindowLevel`, and `alwaysOnTop` defaults true, so `.screenSaver` is unreachable. `.floating` does not sit above another application's full-screen window, and an interrupt a full-screen editor covers is not an interrupt. The collection behaviour at `:257` is already the right half of the answer. Make `alwaysOnTop` a floor rather than an override: take the higher of `.floating` and the requested level. It is an observable behaviour change, so both hand-written client literals must be re-read and re-verified after it, not merely recompiled.
+
+**The two Swift 6 concurrency warnings.** `OverlayWindowManager.swift:422-423` captures a non-`Sendable` `() -> Void` inside a `@Sendable` completion handler and calls main-actor-isolated `NSWindow.close()` from a synchronous nonisolated context. `Package.swift:1` declares swift-tools-version 6.1, so these are the sort of warning a future toolchain promotes to error. They sit in `animateDismiss` (`:414-425`), which every dismissal funnels through — and this work adds four dismissal paths. Fix them here rather than quadrupling the caller count of a function that already warns.
+
+## Rollout
+
+1. **In `simple-alerts`, commit the pending fix alone.** The uncommitted edit at `Sources/VibeNotify/Views/SVGNotificationView.swift:37` changes the dark-mode glow from `.white` to `.green`; `changelog/30112025-adaptive-theme-support.md:16` already documents green, so shipped-white is the bug and this is the unshipped fix. Its own commit, so it is bisectable.
+2. **Fix the test target and the CI trigger.** Nothing else lands until `swift test` passes on `main`.
+3. **Land the library work on a branch and merge to `main`.**
+4. **Tag `0.0.6` and push the tag.** The workflow triggers only on `*.*.*` tags — pushing the tag *is* the release.
+5. **In `core`, re-resolve.** Bump `from: "0.0.5"` to `"0.0.6"` at `clients/macos-swift/VibeCare/Package.swift:32` and update **both** resolved files in the same commit: `clients/macos-swift/VibeCare/Package.resolved:266-272` and `clients/macos-swift/VibeCare/vibecare.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved:266-272`, both currently pinning revision `c74f2acd745eaaa2db31741b33bbcadd6bc3d664` / version `0.0.5`. `from:` is up-to-next-major and already admits 0.0.6, so the manifest edit documents intent; what moves the app is re-resolving. Both files must move together because two build systems each keep their own, and two disagreeing `Package.resolved` files is a failure this tree has already had once.
+6. **Retarget the two client files** in a separate commit from the version bump, so a bisect can distinguish "the new library broke something" from "the retarget broke something".
+
+**Verifying in the real app.** Use `just swift-run-app`, not `just swift-run`: the justfile comment at `:1097-1099` records why — the Xcode build embeds an Info.plist and `swift run` produces a bare CLI binary, which is a real behavioural difference and not the artifact users get.
+
+Reproduce the original bug deliberately before confirming the fix: split the desktop black-terminal-left, white-browser-right, and fire a 20-20-20 schedule notification through `NotificationManager.showScheduleNotification` (`:41`). Title and message must be legible over both halves in both system appearances — the light-mode case currently renders black text with a `.clear` shadow and is the one most likely to be forgotten. Then, in order: an ambient alert over the same backdrop with no dim; ESC, click-anywhere and an explicit button each dismissing an interrupt; a countdown cancelled by early dismissal *not* firing afterwards; a Done press producing an acknowledgement rather than a completion claim; and a plugin alert still rendering through `PluginAlertPresenter.show` at its existing geometry.
+
+**Rollback** is reverting core's `Package.swift` and both resolved files to 0.0.5 and rebuilding. The tag stays published. There is no migration and no persisted state anywhere in this work.
+
+## Deferred
+
+- **Snooze rescheduling.** A guarantees the button cancels the clock and closes the window; what "snooze" *does* to a schedule is B's, once `schedule_actions` carries a time offset.
+- **Driving the task timer from a schedule.** A builds the timer and the plumbing; nothing in A knows how long an exercise lasts.
+- **An explicit presentation key in the action parameters** that `deserializeNotificationPreferences` (`NotificationManager.swift:152-189`) reads, so "interrupt me" and "blur the background" become independently selectable. Deriving one from the other is right for A and would be wrong forever.
+- **Recording break outcomes anywhere.** The completion state dies with the window.
+- **The `appearance` blob**, and therefore any per-plugin control over mode, ring or footnote. C.
+- **Restyling the banner/toast family** (`showSuccess`/`showError`/`showWarning`/`showInfo`/`showToast`). They keep their opaque card; the card rejection was aimed at the break alert.
+- **Removing the deprecated `showSVG` / `SVGNotification` / `SVGNotificationView` symbols.** A 1.0 concern.
+
+## Open questions
+
+**Whether ambient alerts show a card or suppress themselves under Reduce Transparency.** A feathered scrim *is* a transparency gradient and cannot be made opaque and stay edgeless. The two honest options are promoting the ambient text block to an opaque surface with a defined edge — the card the user rejected — or suppressing ambient alerts entirely for those users. Dropping the scrim and relying on shadows alone fails 4.5:1 over a light desktop and is not an option. **The user decides**, before implementation; the implementer must not pick.
+
+**Whether pressing Done while the task timer is still running should dismiss immediately or let the ring finish.** This spec proposes dismiss-immediately with an acknowledgement label. **The user decides** on seeing it run.
+
+**The length of the completion beat** before a task-timer-only alert dismisses itself. Proposed: 1.5s. A feel decision; **the user decides** on seeing it run.
+
+**Whether an interrupt should take key/focus** in addition to sitting above other windows. Separate from window level, with real consequences for whatever the user is typing into. **The user decides.**
+
+**Whether the `NSVisualEffectView` fallback ever becomes the default backdrop.** It gives supported, App-Store-safe blur but only a fixed vocabulary of materials, so `ScreenBlurIntensity`'s 10/25/50 would collapse into two or three and `.custom` would become approximate. It hinges entirely on whether App Store distribution becomes a goal. **The user decides**; A neither builds nor defaults to it.
+
+**The exact CGS minimum background alpha.** `OverlayWindowManager.swift:288` says "~0.1 minimum" with no measurement behind it. **The implementer re-measures** on macOS 14 and 15 and adjusts the clamp floor. Nothing above the floor changes either way, so this does not block the design.
+
+**Whether Xcode honours `swift package edit`.** `just swift-run-app` builds through `xcodebuild`, which resolves via its own `XCRemoteSwiftPackageReference` and its own `Package.resolved` — a different resolution from `.build/workspace-state.json`. **The first developer to iterate** answers this and records the answer in the library README, along with the Xcode-side equivalent (adding the local package folder to the project window so it shadows the remote reference) if the override is ignored. This matters because `swift-run-app` is the only build that produces a real `.app`.
+
+**Whether `fittingHeight` (`PluginAlertOverlay.swift:224-231`) becomes deletable.** It survives in A only because the `appearance` blob was authored for a buttonless alert. If `.ambient` windows self-size to their content, it goes. **The implementer decides** while building the ambient geometry, and deletes it if self-sizing lands.


### PR DESCRIPTION
> [!NOTE]
> Unblocked. `vibe-notify-macos` `0.0.6` is published, the manifest and **both** `Package.resolved` files are bumped to it, and the local `swift package edit` override is gone. This builds from a clean clone.

## Why

The 20-20-20 eye break rendered its title and message invisibly over a split desktop — dark terminal on one half, white browser on the other. The cause was in the notification library (see the linked PR): text colour was derived from the system appearance rather than from what was actually behind the text.

Fixing it properly also unlocked the things that alert had always been missing: a countdown, buttons, and a way to configure any of it once instead of per notification.

## What changed here

**Both notification paths now render through the new renderer.** The schedule path derives its mode from screen blur — enabled means a full-screen interrupt, disabled means a small floating alert. `PluginAlertOverlayView` and its private button style are **deleted** (−180 lines): that view existed only because the old library could not draw an illustration and buttons together, and its doc comment was an inventory of limitations that no longer exist. `PluginAlertPresenter.show` keeps its six-parameter signature byte for byte, so `PluginShellService` and every plugin-alert test are untouched.

**Break countdown.** An action can set `task_timer_seconds` (plus optional `task_timer_unit_label` / `task_timer_completion_label`) and gets the big ring with Done / Skip. No proto change, no migration, no CLI contract bump — `Action.parameters` is already a free-form string map.

Completion is honest: reaching zero says "Break complete"; pressing Done at second three says "Got it", never claiming a break that was skipped.

**Global notification settings** — a filled-out Settings → Notifications pane: position, size, blur and intensity, screen dim, auto-dismiss, moveable, break wording, backdrop, and a Preview that fires through the *same* funnel real notifications use. Global values are defaults; a per-action value still overrides them, and the per-action appearance controls are demoted to a closed "Advanced" disclosure rather than removed.

**Break backdrops.** A break can replace the blurred desktop with a calm solid or gradient — staring at your own blurred work for twenty seconds is not restful. Legibility is guaranteed by construction rather than by convention.

## Fixed along the way

`ProfileService.updateProfile` never set `request.preferences` on the wire, so **every profile preference edit has been silently dropped**, not just the new ones. Verified against a throwaway database with real gRPC calls.

## Scope

No backend, proto, CLI, plugin or SDK changes. `PluginInterrupt.swift` and `NotificationManager`'s public surface are untouched, and all seven `NotificationPolicy` guards stay client-side.

## Testing

Existing suites pass unmodified. Per the author's instruction, new test-writing was paused in favour of feature completeness — the notification surface has been verified by running the app and by the library's demo harness rather than by new client tests.

## Not included

Staged alerts (a pre-warning at T−60s, completion at T+20s) need a time offset on the `schedule_actions` join table — designed but not built. Snooze is deliberately absent, since snooze rescheduling needs that same work and a button that silently does nothing is worse than no button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
