### PR TITLE
feat(server): one server per database

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -56,5 +56,11 @@ just lint              # golangci-lint
 - RRule library follows RFC 5545 for recurring schedule calculations
 - Tracing enabled by default (`--enable-tracing`), OTLP endpoint: `localhost:4317`
 - MCP server can run embedded (`--with-mcp`) or standalone (`cmd/mcp-server/`)
+- **One server per database.** Startup takes an exclusive `flock` on `<db>.lock`; a second
+  server on the same database exits non-zero naming the holder's PID. To run one beside a
+  live server use `--db <other path>` — a different `--port` is not enough, since both
+  would still share `~/.vibecare/vibecare.db` and race over `next_execution`. Readers
+  (`just inspect-db`, sqlite3) never take the lock. See
+  [the design](../docs/superpowers/specs/2026-08-18-single-instance-db-lock-design.md).
 
 For full architecture details, see [`docs/architecture.md`](../docs/architecture.md).

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"log"
@@ -178,6 +179,23 @@ func main() {
 			logger.Fatal("Failed to create database directory", zap.Error(err))
 		}
 	}
+
+	// Claim the database before opening it. Two servers sharing one database each run a
+	// scheduler loop and race over the same next_execution column - the port check cannot
+	// catch that, since --port is what a second server is given in the first place.
+	// Taking the lock first also keeps two servers from running migrations at once.
+	dbLock, err := storage.AcquireDBLock(*dbPath)
+	if err != nil {
+		var locked *storage.ErrLocked
+		if errors.As(err, &locked) {
+			logger.Fatal("Another server already has this database",
+				zap.String("path", *dbPath),
+				zap.Int("holder_pid", locked.HolderPID),
+				zap.String("remedy", "stop that server, or run with --db <other path>"))
+		}
+		logger.Fatal("Failed to lock database", zap.String("path", *dbPath), zap.Error(err))
+	}
+	defer dbLock.Release()
 
 	// Initialize database
 	logger.Info("Opening database", zap.String("path", *dbPath))

--- a/backend/cmd/server/main_test.go
+++ b/backend/cmd/server/main_test.go
@@ -1,9 +1,15 @@
 package main
 
 import (
+	"errors"
+	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"testing"
+	"time"
 )
 
 // resolvePluginsDirs is what makes a brew-installed VibeCare find the
@@ -90,4 +96,93 @@ func TestResolvePluginsDirsToleratesUnknownExeDir(t *testing.T) {
 	if bundled != "" {
 		t.Fatalf("bundled = %q, want none", bundled)
 	}
+}
+
+// A second server sharing a database is not a hypothetical: three of them ran for four
+// days against ~/.vibecare/vibecare.db, each on its own port, each running a scheduler
+// loop, racing over the same next_execution column. The port check cannot catch that -
+// --port is exactly what those servers were given - so the guard is on the database, and
+// this test runs the real binary twice on different ports to prove it.
+func TestSecondServerOnTheSameDatabaseRefusesToStart(t *testing.T) {
+	if testing.Short() {
+		t.Skip("builds and runs the server binary")
+	}
+
+	binary := buildServer(t)
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "vibecare.db")
+	pluginsDir := filepath.Join(dir, "plugins")
+	if err := os.MkdirAll(pluginsDir, 0755); err != nil {
+		t.Fatalf("creating empty plugins dir: %v", err)
+	}
+
+	// Port 0 on both: the two servers never contend for a port, only for the database.
+	args := []string{
+		"--db", dbPath,
+		"--port", "0",
+		"--web-port", "0",
+		"--plugins-dir", pluginsDir,
+		"--enable-tracing=false",
+	}
+
+	first := exec.Command(binary, args...)
+	first.Stdout, first.Stderr = io.Discard, io.Discard
+	if err := first.Start(); err != nil {
+		t.Fatalf("starting first server: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = first.Process.Kill()
+		_ = first.Wait()
+	})
+	waitForLockHeldBy(t, dbPath, first.Process.Pid)
+
+	second := exec.Command(binary, args...)
+	output, err := second.CombinedOutput()
+
+	if err == nil {
+		_ = second.Process.Kill()
+		t.Fatal("second server started against a database another server already holds")
+	}
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("second server should have exited non-zero, got: %v", err)
+	}
+
+	out := string(output)
+	if !strings.Contains(out, dbPath) {
+		t.Errorf("failure should name the database %q; output was:\n%s", dbPath, out)
+	}
+	if !strings.Contains(out, strconv.Itoa(first.Process.Pid)) {
+		t.Errorf("failure should name the holding pid %d; output was:\n%s", first.Process.Pid, out)
+	}
+}
+
+// buildServer compiles the server under test, so the test exercises the real startup path
+// rather than a re-implementation of it.
+func buildServer(t *testing.T) string {
+	t.Helper()
+
+	binary := filepath.Join(t.TempDir(), "vibecare-server")
+	build := exec.Command("go", "build", "-o", binary, ".")
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("building server: %v\n%s", err, out)
+	}
+	return binary
+}
+
+// waitForLockHeldBy blocks until the server has taken the database lock, which is the
+// point after which a second server must be refused.
+func waitForLockHeldBy(t *testing.T, dbPath string, pid int) {
+	t.Helper()
+
+	deadline := time.Now().Add(60 * time.Second)
+	for time.Now().Before(deadline) {
+		if content, err := os.ReadFile(dbPath + ".lock"); err == nil {
+			if strings.TrimSpace(string(content)) == strconv.Itoa(pid) {
+				return
+			}
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("server %d never took the lock on %s", pid, dbPath)
 }

--- a/backend/internal/storage/dblock.go
+++ b/backend/internal/storage/dblock.go
@@ -1,0 +1,127 @@
+package storage
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// errLockHeld reports that another process holds the lock. Platform implementations of
+// tryLockFile return it; AcquireDBLock turns it into an *ErrLocked.
+var errLockHeld = errors.New("lock held by another process")
+
+// ErrLocked is returned when another process already has the database.
+type ErrLocked struct {
+	Path string
+	// HolderPID is the process holding the lock, or 0 when it could not be read. It comes
+	// from the lock file's contents, which is advisory - the lock itself belongs to the
+	// kernel.
+	HolderPID int
+}
+
+func (e *ErrLocked) Error() string {
+	if e.HolderPID == 0 {
+		return fmt.Sprintf("another vibecare-server already has %s open - stop it, or run with --db <other path>", e.Path)
+	}
+	return fmt.Sprintf("another vibecare-server (pid %d) already has %s open - stop it, or run with --db <other path>",
+		e.HolderPID, e.Path)
+}
+
+// DBLock is an exclusive claim on a database, held for as long as the process lives.
+type DBLock struct {
+	file *os.File
+	path string
+}
+
+// AcquireDBLock takes an exclusive advisory lock on dbPath, so that only one server runs a
+// scheduler against it. Several servers sharing a database each run their own scheduler
+// loop and race over the same next_execution column, which is silent, hard to spot, and
+// looks exactly like a scheduling bug.
+//
+// The lock lives on a sidecar file, <dbPath>.lock, and is held by the kernel: it is
+// released when the process exits for any reason, including a crash or SIGKILL, so a dead
+// holder never locks a database out. Readers - sqlite3, litecli, `just inspect-db` - never
+// take it and are never refused.
+//
+// Returns *ErrLocked if another process holds the database.
+func AcquireDBLock(dbPath string) (*DBLock, error) {
+	lockPath := dbPath + ".lock"
+
+	// The lock file is created once and never removed. Deleting it on release would race:
+	// another process can hold the lock on the deleted inode while a third creates a fresh
+	// file and locks that one instead.
+	file, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0644)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open lock file %s: %w", lockPath, err)
+	}
+
+	if err := tryLockFile(file); err != nil {
+		holder := readHolderPID(file)
+		file.Close()
+		if errors.Is(err, errLockHeld) {
+			return nil, &ErrLocked{Path: dbPath, HolderPID: holder}
+		}
+		return nil, fmt.Errorf("failed to lock %s: %w", lockPath, err)
+	}
+
+	if err := writeHolderPID(file); err != nil {
+		unlockFile(file)
+		file.Close()
+		return nil, fmt.Errorf("failed to record pid in %s: %w", lockPath, err)
+	}
+
+	return &DBLock{file: file, path: dbPath}, nil
+}
+
+// Release drops the lock. It is safe to call more than once, and safe to defer.
+func (l *DBLock) Release() error {
+	if l == nil || l.file == nil {
+		return nil
+	}
+
+	file := l.file
+	l.file = nil
+
+	if err := unlockFile(file); err != nil {
+		file.Close()
+		return fmt.Errorf("failed to unlock %s: %w", file.Name(), err)
+	}
+	return file.Close()
+}
+
+// writeHolderPID records who holds the lock, for the error message a blocked server prints.
+func writeHolderPID(file *os.File) error {
+	if err := file.Truncate(0); err != nil {
+		return err
+	}
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		return err
+	}
+	if _, err := file.WriteString(strconv.Itoa(os.Getpid()) + "\n"); err != nil {
+		return err
+	}
+	return file.Sync()
+}
+
+// readHolderPID reads the pid the holder recorded. A missing or unreadable pid is not an
+// error: the lock is real either way, and the pid only improves the message.
+func readHolderPID(file *os.File) int {
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		return 0
+	}
+
+	buf := make([]byte, 32)
+	n, err := file.Read(buf)
+	if n == 0 || (err != nil && err != io.EOF) {
+		return 0
+	}
+
+	pid, err := strconv.Atoi(strings.TrimSpace(string(buf[:n])))
+	if err != nil {
+		return 0
+	}
+	return pid
+}

--- a/backend/internal/storage/dblock_test.go
+++ b/backend/internal/storage/dblock_test.go
@@ -1,0 +1,255 @@
+package storage
+
+import (
+	"bufio"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// TestAcquireDBLock_SecondAcquireIsRefused is the guard itself: two servers pointed at one
+// database must not both start.
+func TestAcquireDBLock_SecondAcquireIsRefused(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "vibecare.db")
+
+	first, err := AcquireDBLock(dbPath)
+	if err != nil {
+		t.Fatalf("first acquire should succeed, got: %v", err)
+	}
+	defer first.Release()
+
+	second, err := AcquireDBLock(dbPath)
+	if err == nil {
+		second.Release()
+		t.Fatal("second acquire succeeded; the database is not guarded")
+	}
+
+	var locked *ErrLocked
+	if !errors.As(err, &locked) {
+		t.Fatalf("expected *ErrLocked, got %T: %v", err, err)
+	}
+	if locked.Path != dbPath {
+		t.Errorf("ErrLocked.Path = %q, want %q", locked.Path, dbPath)
+	}
+}
+
+// TestAcquireDBLock_ErrorNamesTheHolder - the error exists to tell a human which process to
+// stop, so the PID has to survive into it.
+func TestAcquireDBLock_ErrorNamesTheHolder(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "vibecare.db")
+
+	first, err := AcquireDBLock(dbPath)
+	if err != nil {
+		t.Fatalf("first acquire should succeed, got: %v", err)
+	}
+	defer first.Release()
+
+	_, err = AcquireDBLock(dbPath)
+	var locked *ErrLocked
+	if !errors.As(err, &locked) {
+		t.Fatalf("expected *ErrLocked, got %T: %v", err, err)
+	}
+	if locked.HolderPID != os.Getpid() {
+		t.Errorf("HolderPID = %d, want this process %d", locked.HolderPID, os.Getpid())
+	}
+
+	msg := locked.Error()
+	if !strings.Contains(msg, dbPath) {
+		t.Errorf("error message %q should name the database path", msg)
+	}
+	if !strings.Contains(msg, strconv.Itoa(os.Getpid())) {
+		t.Errorf("error message %q should name the holding pid", msg)
+	}
+}
+
+// TestAcquireDBLock_ReleaseFreesIt covers the ordinary restart: stop the server, start it
+// again.
+func TestAcquireDBLock_ReleaseFreesIt(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "vibecare.db")
+
+	first, err := AcquireDBLock(dbPath)
+	if err != nil {
+		t.Fatalf("first acquire should succeed, got: %v", err)
+	}
+	if err := first.Release(); err != nil {
+		t.Fatalf("release failed: %v", err)
+	}
+
+	second, err := AcquireDBLock(dbPath)
+	if err != nil {
+		t.Fatalf("acquire after release should succeed, got: %v", err)
+	}
+	if err := second.Release(); err != nil {
+		t.Fatalf("second release failed: %v", err)
+	}
+	// Release is deferred at call sites, and a double release must not be a crash.
+	if err := second.Release(); err != nil {
+		t.Errorf("release should be idempotent, second call returned: %v", err)
+	}
+}
+
+// TestAcquireDBLock_DifferentDatabasesDoNotConflict keeps `--db /tmp/scratch.db` working as
+// the supported way to run a second server.
+func TestAcquireDBLock_DifferentDatabasesDoNotConflict(t *testing.T) {
+	dir := t.TempDir()
+
+	live, err := AcquireDBLock(filepath.Join(dir, "vibecare.db"))
+	if err != nil {
+		t.Fatalf("acquire on live db failed: %v", err)
+	}
+	defer live.Release()
+
+	scratch, err := AcquireDBLock(filepath.Join(dir, "scratch.db"))
+	if err != nil {
+		t.Fatalf("a different database must not be blocked, got: %v", err)
+	}
+	defer scratch.Release()
+}
+
+// TestAcquireDBLock_AcrossProcesses is the test that matters. The incident this guards
+// against was four separate processes, and an in-process check would also pass under a
+// POSIX fcntl lock, which hands the same process a second lock without complaint.
+func TestAcquireDBLock_AcrossProcesses(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "vibecare.db")
+
+	holder := startLockHolder(t, dbPath)
+
+	_, err := AcquireDBLock(dbPath)
+	if err == nil {
+		t.Fatal("acquired a lock held by another process")
+	}
+
+	var locked *ErrLocked
+	if !errors.As(err, &locked) {
+		t.Fatalf("expected *ErrLocked, got %T: %v", err, err)
+	}
+	if locked.HolderPID != holder.pid {
+		t.Errorf("HolderPID = %d, want the child process %d", locked.HolderPID, holder.pid)
+	}
+}
+
+// TestAcquireDBLock_KilledHolderLeavesNothingBehind is why this uses flock rather than a pid
+// file. The stale servers behind this guard had been orphaned for four days; a crashed or
+// SIGKILLed holder must not lock the database out forever.
+func TestAcquireDBLock_KilledHolderLeavesNothingBehind(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "vibecare.db")
+
+	holder := startLockHolder(t, dbPath)
+	if _, err := AcquireDBLock(dbPath); err == nil {
+		t.Fatal("lock should be held while the child is alive")
+	}
+
+	holder.kill(t)
+
+	lock, err := AcquireDBLock(dbPath)
+	if err != nil {
+		t.Fatalf("a SIGKILLed holder should leave no lock behind, got: %v", err)
+	}
+	lock.Release()
+}
+
+// --- helper process plumbing ---
+
+const (
+	helperEnv     = "VIBECARE_DBLOCK_HELPER"
+	helperPathEnv = "VIBECARE_DBLOCK_PATH"
+)
+
+type lockHolder struct {
+	cmd *exec.Cmd
+	pid int
+}
+
+// startLockHolder re-executes this test binary as a child that acquires the lock and then
+// blocks, returning once the child confirms it holds it.
+func startLockHolder(t *testing.T, dbPath string) *lockHolder {
+	t.Helper()
+
+	cmd := exec.Command(os.Args[0], "-test.run=TestHelperProcess", "-test.timeout=90s")
+	cmd.Env = append(os.Environ(), helperEnv+"=1", helperPathEnv+"="+dbPath)
+	cmd.Stderr = os.Stderr
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatalf("stdout pipe: %v", err)
+	}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("starting lock holder: %v", err)
+	}
+
+	ready := make(chan string, 1)
+	go func() {
+		scanner := bufio.NewScanner(stdout)
+		for scanner.Scan() {
+			if line := scanner.Text(); strings.HasPrefix(line, "locked ") {
+				ready <- line
+				return
+			}
+		}
+		close(ready)
+	}()
+
+	select {
+	case line, ok := <-ready:
+		if !ok {
+			t.Fatal("lock holder exited without acquiring the lock")
+		}
+		pid, err := strconv.Atoi(strings.TrimPrefix(line, "locked "))
+		if err != nil {
+			t.Fatalf("lock holder reported an unreadable pid in %q: %v", line, err)
+		}
+		if pid != cmd.Process.Pid {
+			t.Fatalf("lock holder reported pid %d but was started as %d", pid, cmd.Process.Pid)
+		}
+		holder := &lockHolder{cmd: cmd, pid: pid}
+		// Always reap the child, including when the test fails early - a leaked holder
+		// sleeps on the test binary's stdout and stalls the package for a minute.
+		t.Cleanup(holder.stop)
+		return holder
+	case <-time.After(30 * time.Second):
+		_ = cmd.Process.Kill()
+		t.Fatal("timed out waiting for the lock holder to start")
+		return nil
+	}
+}
+
+func (h *lockHolder) kill(t *testing.T) {
+	t.Helper()
+
+	if err := h.cmd.Process.Signal(syscall.SIGKILL); err != nil {
+		t.Fatalf("killing lock holder: %v", err)
+	}
+	// Wait for the kernel to reap it; the lock is gone once the process is.
+	_ = h.cmd.Wait()
+}
+
+func (h *lockHolder) stop() {
+	_ = h.cmd.Process.Kill()
+	_ = h.cmd.Wait()
+}
+
+// TestHelperProcess is not a test. It runs only when re-executed by startLockHolder, holds
+// the lock, and waits to be killed.
+func TestHelperProcess(t *testing.T) {
+	if os.Getenv(helperEnv) != "1" {
+		t.Skip("helper process; only runs when re-executed by a lock test")
+	}
+
+	lock, err := AcquireDBLock(os.Getenv(helperPathEnv))
+	if err != nil {
+		t.Fatalf("helper failed to acquire the lock: %v", err)
+	}
+	defer lock.Release()
+
+	os.Stdout.WriteString("locked " + strconv.Itoa(os.Getpid()) + "\n")
+
+	// Hold it until the parent kills us. Sleeping (rather than blocking forever) keeps the
+	// runtime's deadlock detector out of it and bounds a leaked child.
+	time.Sleep(60 * time.Second)
+}

--- a/backend/internal/storage/dblock_unix.go
+++ b/backend/internal/storage/dblock_unix.go
@@ -1,0 +1,29 @@
+//go:build !windows
+
+package storage
+
+import (
+	"errors"
+	"os"
+	"syscall"
+)
+
+// tryLockFile takes an exclusive flock without blocking. flock locks are tied to the open
+// file description, so a second os.OpenFile of the same path conflicts even within one
+// process - unlike fcntl locks, which would hand the same process a second lock and quietly
+// defeat the guard.
+func tryLockFile(file *os.File) error {
+	err := syscall.Flock(int(file.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+	switch {
+	case err == nil:
+		return nil
+	case errors.Is(err, syscall.EWOULDBLOCK):
+		return errLockHeld
+	default:
+		return err
+	}
+}
+
+func unlockFile(file *os.File) error {
+	return syscall.Flock(int(file.Fd()), syscall.LOCK_UN)
+}

--- a/backend/internal/storage/dblock_windows.go
+++ b/backend/internal/storage/dblock_windows.go
@@ -1,0 +1,12 @@
+//go:build windows
+
+package storage
+
+import "os"
+
+// The backend has no Windows build, so the lock is a no-op there rather than an untested
+// implementation. LockFileEx is the equivalent when a Windows build appears, and this file
+// is the only one that needs to change.
+func tryLockFile(*os.File) error { return nil }
+
+func unlockFile(*os.File) error { return nil }

--- a/docs/superpowers/specs/2026-08-18-single-instance-db-lock-design.md
+++ b/docs/superpowers/specs/2026-08-18-single-instance-db-lock-design.md
@@ -1,0 +1,178 @@
+# One Server Per Database
+
+**Status:** design, approved for implementation
+**Date:** 2026-08-18
+**Motivated by:** a scheduler bug that was fixed, then kept coming back
+
+---
+
+## 1. What this builds
+
+An advisory lock on the database file, taken by `vibecare-server` at startup. A second
+server pointed at the same database refuses to start, names the process holding it, and
+exits non-zero.
+
+Roughly sixty lines in `backend/internal/storage/`, eight in `cmd/server/main.go`.
+
+---
+
+## 2. The incident
+
+A `FREQ=MINUTELY;INTERVAL=20` schedule reported its next run 1h54m out. The cause was
+found and fixed, the fix merged, the server restarted — and the schedule went back to
+firing once a day.
+
+The fix was working. Four backends were running:
+
+| PID | Built | Ports | Has the fix |
+|---|---|---|---|
+| 97529 | Aug 16 | 50051 / 8080 | yes |
+| 4399 | Aug 14 | 50152 / 8099 | no |
+| 11873 | Aug 14 | 50199 / 8097 | no |
+| 61817 | Aug 14 | 50161 / 8096 | no |
+
+All four had `~/.vibecare/vibecare.db` open. All four ran a scheduler loop on a ten-second
+tick. `next_execution` is rewritten by whichever process dispatches first, so the column
+was decided by a race between four processes running two different versions of the
+calculation. The log shows the fixed server holding a clean twenty-minute cadence
+(22:09, 22:29, 22:49, 23:09) until a stale one won a tick and wrote a value a day out.
+
+The three stale servers were started by hand during unrelated plugin work, on spare ports
+so they would not collide with the real one. Their parent shells exited; they were
+reparented to launchd and ran for four days.
+
+---
+
+## 3. Why nothing caught it
+
+`main.go` fatals if `net.Listen` on the gRPC port fails, so a second server on the
+**default** port dies immediately. That is the only singleton guard in the process, and
+`--port` walks straight past it — which is exactly what the stale servers were given.
+
+The database imposes no guard of its own. It is opened `_journal_mode=WAL` with
+`_busy_timeout=5000`, so SQLite serialises writers per transaction and lets any number of
+processes share the file without an error. Correct for its purpose; silent for ours.
+
+The guard belongs on the resource being contended. That resource is the database, not the
+port.
+
+---
+
+## 4. Mechanism
+
+`flock(2)` with `LOCK_EX|LOCK_NB` on a sidecar file, `<dbPath>.lock`.
+
+**The kernel releases it when the process dies** — including `kill -9`, a panic, or a
+crash — so there is no stale lock to detect, expire, or clean up. That property decides
+the design. The processes in §2 had been orphaned for four days; any scheme that records
+a PID and asks "is that still alive?" has to answer for reused PIDs and for the window
+between a crash and the next startup. flock has no such window.
+
+After acquiring, the holder truncates the file and writes its own PID. That content is
+advisory — used only to name the holder in an error message, never to decide whether the
+lock is held. The lock is the kernel's; the PID is a courtesy to whoever reads the error.
+
+Alternatives considered:
+
+| Approach | Rejected because |
+|---|---|
+| PID file with liveness check | Stale PIDs after a crash; PID reuse; races between check and write |
+| `BEGIN EXCLUSIVE` held open | Blocks every other writer including `just inspect-db`, and fights WAL |
+| Bind a second sentinel port | Same flaw as today: a flag moves the port and the guard evaporates |
+| Lock the database file itself | SQLite owns that file's locking; a second scheme on it invites deadlock |
+
+---
+
+## 5. Contract
+
+```go
+// storage/dblock.go
+func AcquireDBLock(dbPath string) (*DBLock, error)
+func (l *DBLock) Release() error
+
+type ErrLocked struct {
+    Path      string
+    HolderPID int  // 0 when the holder's PID could not be read
+}
+```
+
+`AcquireDBLock` returns `*ErrLocked` when another process holds the lock, and an ordinary
+error if the lock file cannot be created or locked for any other reason. `Release` is
+idempotent and safe to `defer`.
+
+**Placement.** `cmd/server/main.go`, immediately *before* `storage.New(*dbPath)`. Taking
+it first also stops two servers from running goose migrations concurrently.
+
+Deliberately **not** inside `storage.New`. Tests construct databases constantly, and a
+future read-only tool should not have to defeat a lock meant for the scheduler. The
+server owns the singleton, so the server takes the lock.
+
+**On conflict**, `logger.Fatal` with a message that says what to do:
+
+```
+another vibecare-server (pid 4399) already has /Users/x/.vibecare/vibecare.db open
+ - stop it, or run with --db <other path>
+```
+
+**Lock file lifecycle.** Created `0644` beside the database, never deleted. Deleting it on
+release would race: a second process can be holding the deleted inode's lock while a third
+creates a fresh file and locks that instead. A zero-cost empty file is the cheaper answer.
+
+Relative paths, `..`, and symlinks need no normalisation — `flock` locks an inode, and
+every spelling of the same path resolves to the same one. Two *hardlinks* to one database
+would evade the lock; that is a known limit, not worth code.
+
+---
+
+## 6. What stays unguarded, on purpose
+
+- **Readers.** `just inspect-db`, `sqlite3`, litecli. They never take the lock and are
+  never refused.
+- **Tests.** `storage.New` is untouched, so every test that builds a database in a temp
+  directory behaves exactly as before.
+- **A deliberate second instance.** `--db /tmp/scratch.db` locks its own path and starts
+  normally. That is the supported way to run a server beside a live one, and it is what
+  the stale servers in §2 should have been given.
+
+No override flag. An `--allow-multiple-instances` escape hatch would be pasted into a
+script once and reproduce this incident with the guard still nominally in place.
+
+---
+
+## 7. Portability
+
+`dblock_unix.go` (`//go:build !windows`) carries the real implementation.
+`dblock_windows.go` is a documented no-op that always succeeds — the backend has no
+Windows build today, and a stub keeps the package compiling if one appears. When Windows
+becomes real, `LockFileEx` is the equivalent and this is the only file that changes.
+
+---
+
+## 8. Testing
+
+`backend/internal/storage/dblock_test.go`:
+
+| Test | Proves |
+|---|---|
+| Second acquire on the same path fails with `*ErrLocked` | The guard guards |
+| The error carries the holder's PID | The message can name a process to kill |
+| Acquire, release, acquire again | Release actually releases |
+| Two different paths | Per-database, not global |
+| **A child process holds it; the parent is refused** | It works across processes, which is the whole point |
+| **`kill -9` the child, then acquire** | A crashed holder leaves nothing behind |
+
+The last two spawn a real subprocess via the `TestHelperProcess` re-exec pattern. They are
+the tests that matter: the in-process cases would also pass under a POSIX `fcntl` lock,
+which silently grants the second acquire to the same process and would have been useless
+here.
+
+---
+
+## 9. What this does not fix
+
+Two servers on two *different* databases still both run schedulers, and both still fire
+notifications. Nothing in this design addresses that, and nothing needs to: they are not
+racing over shared rows.
+
+The orphaning itself is also untouched — killing a `go run` parent still leaves the child
+running. This design makes the consequence loud rather than preventing the cause.


### PR DESCRIPTION
## Why

Yesterday's scheduler fix was merged, the server restarted, and the 20-minute schedule went straight back to firing once a day.

The fix was fine. **Four** backends were running against `~/.vibecare/vibecare.db`:

| PID | Built | Ports | Has the fix |
|---|---|---|---|
| 97529 | Aug 16 | 50051 / 8080 | yes |
| 4399 | Aug 14 | 50152 / 8099 | no |
| 11873 | Aug 14 | 50199 / 8097 | no |
| 61817 | Aug 14 | 50161 / 8096 | no |

Each ran its own scheduler on a ten-second tick. `next_execution` is rewritten by whichever process dispatches first, so the column was decided by a race between processes running two different versions of the calculation. The logs show the fixed server holding a clean twenty-minute cadence — 22:09, 22:29, 22:49, 23:09 — until a stale one won a tick and wrote a value a day out.

The three stale servers were started by hand during unrelated plugin work, on spare ports so they wouldn't collide with the real one. Their parent shells exited, they were reparented to launchd, and they ran for four days.

## What wasn't protecting us

`main.go` already dies if the gRPC port is taken — that's the only singleton guard in the process, and `--port` walks straight past it. Which is precisely what those servers were given.

The database had no guard at all. It opens in WAL mode with a busy timeout, so SQLite serialises writers per transaction and lets any number of processes share the file without complaint. That's correct for SQLite's purpose and silent for ours.

So put the guard on the thing actually being fought over: the database, not the port.

## What this does

On startup, before opening the database, the server takes an exclusive `flock` on `<db>.lock`. A second server on the same database exits non-zero:

```
FATAL  Another server already has this database
       {"path": "/Users/x/.vibecare/vibecare.db", "holder_pid": 4399,
        "remedy": "stop that server, or run with --db <other path>"}
```

**Why flock and not a PID file:** the kernel drops the lock when the process dies — `kill -9`, panic, crash, anything. There's no stale lock to detect or expire. That mattered here: the holders had been orphaned for four days, and any scheme that writes a PID and later asks "is that still alive?" has to answer for reused PIDs and for the gap between a crash and the next startup. The holder does write its PID into the file, but purely so the error message can name it — the lock itself is the kernel's.

Taking it before `storage.New` also stops two servers from running goose migrations at the same time.

## What stays unguarded, deliberately

- **Readers** — `just inspect-db`, sqlite3, litecli. They never take the lock, never get refused.
- **Tests** — `storage.New` is untouched, so every test that builds a database in a temp dir behaves exactly as before.
- **A deliberate second instance** — `--db /tmp/scratch.db` locks its own path and starts normally. That's the supported way to run a server beside a live one, and it's what those three stale servers should have been given.

No `--allow-multiple-instances` flag. An escape hatch gets pasted into a script once and reproduces this incident with the guard still nominally in place.

## Tests

Six unit tests in `storage`, plus one end-to-end test that builds the real binary and starts it twice.

The end-to-end test runs both servers on `--port 0`, so they never contend for a port — only for the database. That's the exact shape of the incident and the shape the port check can't see.

Two of the unit tests spawn a real child process. They're the ones that matter: the in-process cases would also pass under a POSIX `fcntl` lock, which hands the same process a second lock without complaint and would have been useless here. One of them `kill -9`s the holder and then acquires, proving a crashed server leaves nothing behind.

I also mutation-tested the suite — with the `flock` call removed, 4 of 6 unit tests fail, including both cross-process ones. The tests fail when the guard is gone, which is the only evidence that they're testing the guard.

Full backend suite green; `gofmt` and `go vet` clean; the package cross-compiles for Windows (the stub there is a documented no-op, since there's no Windows build yet).

## Doesn't fix

Two servers on two *different* databases still both run schedulers and both fire notifications — but they aren't racing over shared rows, so that's out of scope. And killing a `go run` parent still orphans its child; this makes the consequence loud rather than preventing the cause.

Design doc: `docs/superpowers/specs/2026-08-18-single-instance-db-lock-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)