### PR TITLE
Break activities: embed a page beside the countdown

### DIFF
--- a/clients/macos-swift/VibeCare/CLAUDE.md
+++ b/clients/macos-swift/VibeCare/CLAUDE.md
@@ -135,6 +135,13 @@ no global counterpart (what to load during a break is content, not appearance):
 | `web_side` | `leading` (default) or `trailing` — which side the page takes |
 | `web_width` | The page's share of the surface width, `0.3`–`0.85` |
 | `web_autoplay` | `true` / `false` — may media start on its own (default `false`) |
+| `web_loop` | `true` / `false` — restart the video when it ends (default `false`) |
+
+YouTube links of every shape are rewritten to an embedded player: `watch?v=`,
+`youtu.be`, `/shorts/` and `/live/`, keeping any `?t=` start offset. Shorts in
+particular need it — followed directly, a Short plays and then scrolls on to
+the next one, handing the user an infinite feed at the moment the break was
+meant to stop them looking at one.
 
 `plugin:` specs resolve at delivery time through
 `PluginRoster.handoffURL(for:path:)`, which appends the `?vc=` token core swaps

--- a/clients/macos-swift/VibeCare/CLAUDE.md
+++ b/clients/macos-swift/VibeCare/CLAUDE.md
@@ -126,6 +126,26 @@ global counterparts (`screen_blur_enabled`, not `notify.blur_enabled`).
 | `task_timer_unit_label` | The word under the number | `notify.break_unit_label` ("seconds") |
 | `task_timer_completion_label` | What the ring's centre says at zero | `notify.break_completion_label` ("Break complete") |
 
+**Web panel** — turns the break into something the user can do. Action-only,
+no global counterpart (what to load during a break is content, not appearance):
+
+| Key | Value |
+|---|---|
+| `web_url` | `https://…`, or `plugin:<id>` / `plugin:<id>/<path>` |
+| `web_side` | `leading` (default) or `trailing` — which side the page takes |
+| `web_width` | The page's share of the surface width, `0.3`–`0.85` |
+| `web_autoplay` | `true` / `false` — may media start on its own (default `false`) |
+
+`plugin:` specs resolve at delivery time through
+`PluginRoster.handoffURL(for:path:)`, which appends the `?vc=` token core swaps
+for a session cookie. They are stored unresolved on purpose: the base URL and
+the token both change when core restarts, so an already-resolved URL saved into
+an action would be a stale credential in the database. A spec naming a plugin
+that is not in the roster logs and shows **no panel** — a break that opens on
+core's error page is worse than one with no panel. A bare `example.com` is
+rejected rather than upgraded to `https://`, because `URL(string:)` accepts it
+as a relative URL and the panel would then be silently blank.
+
 **Appearance** — global unless the action says otherwise:
 
 | Key | Values |
@@ -137,7 +157,7 @@ global counterparts (`screen_blur_enabled`, not `notify.blur_enabled`).
 | `screen_blur_enabled` | `true` / `false` |
 | `screen_blur_intensity` | `light`, `medium`, `heavy` |
 
-#### Two behaviours that surprise people
+#### Four behaviours that surprise people
 
 **A task timer forces `.interrupt`, whatever `screen_blur_enabled` says.**
 `RichNotification.effectiveTaskTimer` returns `nil` in `.ambient` by design — a
@@ -155,6 +175,20 @@ the task hits zero, so honouring both would total `duration + delay` — the
 very unlikely to be what an author who set a task duration meant. Instead the
 library's own `NotificationClock.completionHold` (1.5s) governs how long the
 completion label holds before the window closes. The ignored value is logged.
+
+**`web_url` forces `.interrupt` too, and takes click-anywhere-to-dismiss
+away.** `RichNotification.effectiveWebPanel` is `nil` in `.ambient` for the
+same reason the task timer is — a 380×210 toast split into two columns is two
+columns too narrow to be either. And `RichNotificationView` suppresses its
+full-bleed tap target whenever a panel is present: everywhere else "click
+anywhere to skip" is a courtesy, but with a game in the panel one shot landing
+in the margin would cancel the break and explain nothing. ESC and the buttons
+remain, and the footnote says so.
+
+**A `web_url` with no `task_timer_seconds` gets a Close button.** Without one
+it would have no buttons (those come with the timer), no click-away (see
+above), and a 3-second `quickDismissDelay` — three seconds of a video, then
+gone. The panel-without-timer case gets a button and no deadline instead.
 
 ## Plugins (v2)
 

--- a/clients/macos-swift/VibeCare/CLAUDE.md
+++ b/clients/macos-swift/VibeCare/CLAUDE.md
@@ -149,7 +149,19 @@ no global counterpart (what to load during a break is content, not appearance):
 | `web_side` | `leading` (default) or `trailing` — which side the page takes |
 | `web_width` | The page's share of the surface width, `0.3`–`0.85` |
 | `web_autoplay` | `true` / `false` — may media start on its own (default `false`) |
+| `web_muted` | `true` / `false` — start with sound off (default **`true`**) |
 | `web_loop` | `true` / `false` — restart the video when it ends (default `false`) |
+
+**Autoplay does not work while macOS Low Power Mode is on**, and this is
+measured, not suspected. WebKit's `RequireUserGestureForVideoDueToLowPowerMode`
+refuses to start any video without a real user gesture — muted or not,
+`autoplay=1` or not, and regardless of
+`mediaTypesRequiringUserActionForPlayback`. It has no muted exemption and no
+API that lifts it. The symptom is a video that loads and displays perfectly,
+shows its play button, and never starts; it cost a long hunt that blamed
+YouTube, the iframe, the origin and the URL parameters first. Nothing detects
+it — the only thing that satisfies the gate is the user pressing play, which
+is the fallback anyway.
 
 YouTube links of every shape are rewritten to an embedded player: `watch?v=`,
 `youtu.be`, `/shorts/` and `/live/`, keeping any `?t=` start offset. Shorts in

--- a/clients/macos-swift/VibeCare/CLAUDE.md
+++ b/clients/macos-swift/VibeCare/CLAUDE.md
@@ -126,6 +126,20 @@ global counterparts (`screen_blur_enabled`, not `notify.blur_enabled`).
 | `task_timer_unit_label` | The word under the number | `notify.break_unit_label` ("seconds") |
 | `task_timer_completion_label` | What the ring's centre says at zero | `notify.break_completion_label` ("Break complete") |
 
+**Rich vs plain** — `notification_style: rich` records which editor an action
+was authored in. There is no ninth `ActionType`: a rich notification and a
+plain one are both `notification` on the wire, because that is what the
+backend schedules and what every other client understands. The split is an
+authoring concern and lives in `ActionKind` — the "Add Action" menu, the
+editor, and the label in the list.
+
+`ActionKind.isRich` deliberately does **not** trust the marker alone: an
+action carrying `task_timer_seconds` or `web_url` is rich whatever it was
+authored in. Without that, every action written by the MCP server, the CLI or
+a routine template would open in the plain editor, which has no controls for
+either — so the author would see its most important settings missing and the
+next save would drop them.
+
 **Web panel** — turns the break into something the user can do. Action-only,
 no global counterpart (what to load during a break is content, not appearance):
 

--- a/clients/macos-swift/VibeCare/Package.resolved
+++ b/clients/macos-swift/VibeCare/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "c4de3702f15e623fbbdd1d4beb40df8caea4200733c9a73e883aca4c6fe728bc",
+  "originHash" : "4a263fa3d08b683469d64ae542c683c427760f460f07a7a7b6756714614d6dc9",
   "pins" : [
     {
       "identity" : "grpc-swift",
@@ -267,8 +267,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vibecare-io/vibe-notify-macos.git",
       "state" : {
-        "revision" : "b0c7c2167481779eaf201018456ea0da1d73b3e6",
-        "version" : "0.0.6"
+        "revision" : "b8284a630f4eba40ffe5f7949b9916a64b1e733d",
+        "version" : "0.0.7"
       }
     }
   ],

--- a/clients/macos-swift/VibeCare/Package.swift
+++ b/clients/macos-swift/VibeCare/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
     // Core package (contains OpenTelemetryApi and OpenTelemetrySdk)
     .package(url: "https://github.com/open-telemetry/opentelemetry-swift-core.git", from: "2.2.0"),
     // customized notification
-    .package(url: "https://github.com/vibecare-io/vibe-notify-macos.git", from: "0.0.6"),
+    .package(url: "https://github.com/vibecare-io/vibe-notify-macos.git", from: "0.0.7"),
   ],
   targets: [
     .target(

--- a/clients/macos-swift/VibeCare/VibeCare/Models/ActionKind.swift
+++ b/clients/macos-swift/VibeCare/VibeCare/Models/ActionKind.swift
@@ -51,11 +51,31 @@ struct ActionKind: Identifiable, Hashable {
     return kinds
   }()
 
+  /// The activity a brand-new rich notification starts with.
+  ///
+  /// The built-in one, deliberately: it is the only entry that needs no
+  /// network, cannot be taken down by its publisher, and is not subject to
+  /// anybody's embedding rules. A default pointing at someone else's video is
+  /// a default that breaks without warning.
+  static let defaultActivityID = "game-blink-jump"
+
   /// The parameters a newly-added action of this kind starts with.
+  ///
+  /// A rich notification arrives already working — countdown on, Blink Jump in
+  /// the panel — rather than as an empty form that renders as a plain toast
+  /// until the author finds the two controls that make it rich. The seed is
+  /// only a starting point; every value is a control on the sheet.
   func seedParameters() -> [String: String] {
     guard type == .notification else { return [:] }
     var seed = ["title": "", "body": ""]
-    if isRich { seed[Self.styleKey] = Self.richStyle }
+    guard isRich else { return seed }
+
+    seed[Self.styleKey] = Self.richStyle
+    if let activity = BreakActivity.all.first(where: { $0.id == Self.defaultActivityID }) {
+      seed["web_url"] = activity.url
+      seed["web_width"] = String(format: "%.2f", activity.widthFraction)
+      seed["task_timer_seconds"] = String(activity.seconds)
+    }
     return seed
   }
 

--- a/clients/macos-swift/VibeCare/VibeCare/Models/ActionKind.swift
+++ b/clients/macos-swift/VibeCare/VibeCare/Models/ActionKind.swift
@@ -1,0 +1,91 @@
+import Foundation
+
+/// What the "Add Action" menu offers, which is deliberately **not** the same
+/// list as `ActionType`.
+///
+/// A rich notification and a plain one are the same `ActionType` on the wire —
+/// `notification` — because that is what the backend schedules, what the CLI
+/// prints and what every other client understands. They are different *things*
+/// to author, though: one is a line of text in a corner, the other takes the
+/// screen, runs a countdown and can embed a page. Burying the second one's
+/// controls inside the first one's editor is what made this worth splitting.
+///
+/// The split therefore lives here, in the menu and the editor, and rides on a
+/// parameter rather than a ninth enum value. A real enum value would mean a
+/// proto change, regenerated stubs on both sides, backend mapping and executor
+/// changes, and an update to every switch over `ActionType` — for a
+/// distinction only the authoring UI makes. If it earns its keep, promoting it
+/// later is mechanical.
+struct ActionKind: Identifiable, Hashable {
+
+  /// The parameter that records which editor an action was authored in.
+  ///
+  /// Only ever `"rich"`. Absent means plain, which is what every action
+  /// predating this reads as — see `isRich(_:)` for why absence alone is not
+  /// enough to conclude it.
+  static let styleKey = "notification_style"
+  static let richStyle = "rich"
+
+  let id: String
+  let title: String
+  let icon: String
+  let type: ActionType
+  let isRich: Bool
+
+  static let all: [ActionKind] = {
+    var kinds: [ActionKind] = [
+      ActionKind(
+        id: "notification", title: "Send Notification", icon: "bell",
+        type: .notification, isRich: false),
+      ActionKind(
+        id: "notification.rich", title: "Send Rich Notification", icon: "sparkles",
+        type: .notification, isRich: true),
+    ]
+    // Everything else keeps its own name and icon, one menu entry each.
+    kinds.append(
+      contentsOf: ActionType.allCases
+        .filter { $0 != .notification }
+        .map {
+          ActionKind(id: $0.rawValue, title: $0.displayName, icon: $0.iconName, type: $0, isRich: false)
+        })
+    return kinds
+  }()
+
+  /// The parameters a newly-added action of this kind starts with.
+  func seedParameters() -> [String: String] {
+    guard type == .notification else { return [:] }
+    var seed = ["title": "", "body": ""]
+    if isRich { seed[Self.styleKey] = Self.richStyle }
+    return seed
+  }
+
+  /// Whether an existing action should open in the rich editor.
+  ///
+  /// The marker is checked first, but **cannot be the only test**. Actions
+  /// authored before this split exists — including every one written by the
+  /// MCP server, the CLI, or a routine template — carry a break countdown or a
+  /// web panel and no marker at all. Deciding purely on the marker would open
+  /// those in the plain editor, which has no controls for either, so the
+  /// author would see an action whose most important settings had silently
+  /// vanished and whose next save would drop them.
+  ///
+  /// So the rich *features* also count as evidence. An action that has one is
+  /// a rich action whatever it was authored in.
+  static func isRich(_ parameters: [String: String]) -> Bool {
+    if parameters[styleKey] == richStyle { return true }
+    return parameters["task_timer_seconds"] != nil || parameters["web_url"] != nil
+  }
+
+  /// What to call an action in a list, where the plain `ActionType.displayName`
+  /// would call a rich notification and a plain one the same thing — the exact
+  /// confusion this split exists to remove.
+  static func displayName(for type: ActionType, parameters: [String: String]) -> String {
+    guard type == .notification, isRich(parameters) else { return type.displayName }
+    return "Send Rich Notification"
+  }
+
+  static func iconName(for type: ActionType, parameters: [String: String]) -> String {
+    guard type == .notification, isRich(parameters) else { return type.iconName }
+    return "sparkles"
+  }
+}

--- a/clients/macos-swift/VibeCare/VibeCare/Models/BreakActivity.swift
+++ b/clients/macos-swift/VibeCare/VibeCare/Models/BreakActivity.swift
@@ -1,0 +1,123 @@
+import Foundation
+
+/// A curated thing to do during a break, ready to drop into an action's
+/// `web_url`.
+///
+/// The list is deliberately short and hand-picked rather than a search box.
+/// A break is twenty seconds long; a user who has to *choose* during it has
+/// already spent the break. The choosing happens once, while authoring the
+/// action, and the catalogue is what makes that choice a click.
+struct BreakActivity: Identifiable, Hashable, Sendable {
+
+  /// What the activity is for. Drives the grouping in the picker and nothing
+  /// else — this is a label, not a taxonomy anything depends on.
+  enum Focus: String, CaseIterable, Identifiable, Sendable {
+    case eyes
+    case neck
+    case breathing
+    case games
+
+    var id: String { rawValue }
+
+    var title: String {
+      switch self {
+      case .eyes: return "Eyes"
+      case .neck: return "Neck & posture"
+      case .breathing: return "Breathing"
+      case .games: return "Move & follow"
+      }
+    }
+  }
+
+  let id: String
+  /// **A description, not the video's own title.** Nothing here has been
+  /// fetched, so claiming to print a publisher's title would be inventing one.
+  /// Rename them freely — the id and the URL are what matter.
+  let title: String
+  let focus: Focus
+  let url: String
+  /// How long a break built around this should run. Shorts get their own
+  /// length; the long routines get a slice, since the point is to do some of
+  /// it, not to sit through all of it.
+  let seconds: Int
+  /// The web column's share of the width.
+  ///
+  /// Shorts are shot vertically. Given the same 64% column a landscape video
+  /// gets, a vertical video is letterboxed into a tall dark frame with two
+  /// black wings — so they ask for a narrow column instead and the rail takes
+  /// the room back.
+  let widthFraction: Double
+
+  /// Vertical (9:16) source material.
+  static let verticalWidthFraction = 0.36
+  /// Landscape (16:9) source material.
+  static let landscapeWidthFraction = 0.64
+
+  // MARK: - The catalogue
+
+  static let all: [BreakActivity] = [
+    // Eyes
+    BreakActivity(
+      id: "eye-short-1", title: "Eye reset — short 1", focus: .eyes,
+      url: "https://www.youtube.com/shorts/eG51cFCbPZs",
+      seconds: 30, widthFraction: verticalWidthFraction),
+    BreakActivity(
+      id: "eye-short-2", title: "Eye reset — short 2", focus: .eyes,
+      url: "https://www.youtube.com/shorts/91O3MT0Xp5g",
+      seconds: 30, widthFraction: verticalWidthFraction),
+    BreakActivity(
+      id: "eye-short-3", title: "Eye reset — short 3", focus: .eyes,
+      url: "https://www.youtube.com/shorts/EOiy1ubLQLA",
+      seconds: 30, widthFraction: verticalWidthFraction),
+
+    // Neck & posture
+    BreakActivity(
+      id: "neck-routine", title: "Neck release — from 1:08", focus: .neck,
+      url: "https://youtu.be/IlCyVaoLR4Y?t=68",
+      seconds: 90, widthFraction: landscapeWidthFraction),
+
+    // Breathing
+    BreakActivity(
+      id: "breathing-guided", title: "Guided breathing", focus: .breathing,
+      url: "https://www.youtube.com/watch?v=5DqTuWve9t8",
+      seconds: 120, widthFraction: landscapeWidthFraction),
+    BreakActivity(
+      id: "breathing-short-1", title: "Breathing — short 1", focus: .breathing,
+      url: "https://www.youtube.com/shorts/FWYkom7Enf8",
+      seconds: 45, widthFraction: verticalWidthFraction),
+    BreakActivity(
+      id: "breathing-short-2", title: "Breathing — short 2", focus: .breathing,
+      url: "https://www.youtube.com/shorts/Cq7nmTw1epA",
+      seconds: 45, widthFraction: verticalWidthFraction),
+    BreakActivity(
+      id: "breathing-wim-hof", title: "Wim Hof breathing (11 min)", focus: .breathing,
+      url: "https://www.youtube.com/watch?v=tybOi4hjZFQ",
+      seconds: 300, widthFraction: landscapeWidthFraction),
+    BreakActivity(
+      id: "breathing-beats", title: "Breath workout beats (9 min)", focus: .breathing,
+      url: "https://www.youtube.com/watch?v=sbTUwTWCzV8",
+      seconds: 300, widthFraction: landscapeWidthFraction),
+
+    // Move & follow
+    BreakActivity(
+      id: "game-follow-short", title: "Follow the dot — short", focus: .games,
+      url: "https://www.youtube.com/shorts/uUVml5pCQxQ",
+      seconds: 45, widthFraction: verticalWidthFraction),
+    BreakActivity(
+      id: "game-eye-exercises", title: "Eye exercise routine", focus: .games,
+      url: "https://www.youtube.com/watch?v=29pQZZWdooY",
+      seconds: 120, widthFraction: landscapeWidthFraction),
+    BreakActivity(
+      id: "game-blink-jump", title: "Blink Jump (built in)", focus: .games,
+      url: "plugin:blink-jump",
+      seconds: 60, widthFraction: landscapeWidthFraction),
+  ]
+
+  static func all(in focus: Focus) -> [BreakActivity] {
+    all.filter { $0.focus == focus }
+  }
+
+  static func activity(withURL url: String) -> BreakActivity? {
+    all.first { $0.url == url }
+  }
+}

--- a/clients/macos-swift/VibeCare/VibeCare/Models/NotificationPreferences.swift
+++ b/clients/macos-swift/VibeCare/VibeCare/Models/NotificationPreferences.swift
@@ -111,6 +111,9 @@ final class NotificationPreferences: Codable, Equatable, Hashable {
     /// Whether media in the panel may start on its own. Off unless the action
     /// says otherwise — see `WebPanel.allowsAutoplay`.
     var webAutoplay: Bool
+    /// Whether the video restarts when it ends. Off unless the action says
+    /// otherwise — see `WebPanel.loops`.
+    var webLoops: Bool
 
     init(
         bundledIconId: String? = nil,
@@ -132,7 +135,8 @@ final class NotificationPreferences: Codable, Equatable, Hashable {
         webURLSpec: String? = nil,
         webPlacement: String? = nil,
         webWidthFraction: CGFloat? = nil,
-        webAutoplay: Bool = false
+        webAutoplay: Bool = false,
+        webLoops: Bool = false
     ) {
         self.bundledIconId = bundledIconId
         self.svgPath = svgPath
@@ -154,6 +158,7 @@ final class NotificationPreferences: Codable, Equatable, Hashable {
         self.webPlacement = webPlacement
         self.webWidthFraction = webWidthFraction
         self.webAutoplay = webAutoplay
+        self.webLoops = webLoops
     }
 
     /// Returns an independent copy of these preferences (a distinct reference,
@@ -180,7 +185,8 @@ final class NotificationPreferences: Codable, Equatable, Hashable {
             webURLSpec: webURLSpec,
             webPlacement: webPlacement,
             webWidthFraction: webWidthFraction,
-            webAutoplay: webAutoplay
+            webAutoplay: webAutoplay,
+            webLoops: webLoops
         )
     }
 

--- a/clients/macos-swift/VibeCare/VibeCare/Models/NotificationPreferences.swift
+++ b/clients/macos-swift/VibeCare/VibeCare/Models/NotificationPreferences.swift
@@ -87,6 +87,31 @@ final class NotificationPreferences: Codable, Equatable, Hashable {
     /// `RichNotification.completionState`.
     var taskTimerCompletionLabel: String?
 
+    // MARK: - Web panel
+
+    /// What to load in the alert's web column, or `nil` for no column at all —
+    /// which is every action that predates this field, unchanged.
+    ///
+    /// Two forms, kept as one string rather than a discriminated pair because
+    /// this is what the author types into a single field:
+    ///
+    /// - `https://…` — loaded as-is.
+    /// - `plugin:<id>` or `plugin:<id>/<path>` — resolved at delivery time
+    ///   through `PluginRoster.handoffURL(for:)`, which is what supplies the
+    ///   session token. Stored unresolved because the roster's base URL and
+    ///   token both change between runs, so an already-resolved URL saved into
+    ///   an action would be a stale credential in the database.
+    var webURLSpec: String?
+    /// `"leading"` or `"trailing"` — which side the web column takes. Anything
+    /// else (including `nil`) means the default, `leading`.
+    var webPlacement: String?
+    /// The web column's share of the surface width. `nil` means VibeNotify's
+    /// own default; the library clamps whatever arrives.
+    var webWidthFraction: CGFloat?
+    /// Whether media in the panel may start on its own. Off unless the action
+    /// says otherwise — see `WebPanel.allowsAutoplay`.
+    var webAutoplay: Bool
+
     init(
         bundledIconId: String? = nil,
         svgPath: String? = nil,
@@ -103,7 +128,11 @@ final class NotificationPreferences: Codable, Equatable, Hashable {
         screenBlurIntensity: BlurIntensity = .medium,
         taskTimerSeconds: TimeInterval? = nil,
         taskTimerUnitLabel: String? = nil,
-        taskTimerCompletionLabel: String? = nil
+        taskTimerCompletionLabel: String? = nil,
+        webURLSpec: String? = nil,
+        webPlacement: String? = nil,
+        webWidthFraction: CGFloat? = nil,
+        webAutoplay: Bool = false
     ) {
         self.bundledIconId = bundledIconId
         self.svgPath = svgPath
@@ -121,6 +150,10 @@ final class NotificationPreferences: Codable, Equatable, Hashable {
         self.taskTimerSeconds = taskTimerSeconds
         self.taskTimerUnitLabel = taskTimerUnitLabel
         self.taskTimerCompletionLabel = taskTimerCompletionLabel
+        self.webURLSpec = webURLSpec
+        self.webPlacement = webPlacement
+        self.webWidthFraction = webWidthFraction
+        self.webAutoplay = webAutoplay
     }
 
     /// Returns an independent copy of these preferences (a distinct reference,
@@ -143,7 +176,11 @@ final class NotificationPreferences: Codable, Equatable, Hashable {
             screenBlurIntensity: screenBlurIntensity,
             taskTimerSeconds: taskTimerSeconds,
             taskTimerUnitLabel: taskTimerUnitLabel,
-            taskTimerCompletionLabel: taskTimerCompletionLabel
+            taskTimerCompletionLabel: taskTimerCompletionLabel,
+            webURLSpec: webURLSpec,
+            webPlacement: webPlacement,
+            webWidthFraction: webWidthFraction,
+            webAutoplay: webAutoplay
         )
     }
 

--- a/clients/macos-swift/VibeCare/VibeCare/Models/NotificationPreferences.swift
+++ b/clients/macos-swift/VibeCare/VibeCare/Models/NotificationPreferences.swift
@@ -111,6 +111,12 @@ final class NotificationPreferences: Codable, Equatable, Hashable {
     /// Whether media in the panel may start on its own. Off unless the action
     /// says otherwise — see `WebPanel.allowsAutoplay`.
     var webAutoplay: Bool
+    /// Whether the player starts with its sound off. **On** unless the action
+    /// says otherwise — see `WebPanel.startsMuted`. Separate from
+    /// `webAutoplay`: muting is a reasonable thing to want for a video the
+    /// user will press play on themselves, and it is also what makes an
+    /// autoplaying one permissible.
+    var webMuted: Bool
     /// Whether the video restarts when it ends. Off unless the action says
     /// otherwise — see `WebPanel.loops`.
     var webLoops: Bool
@@ -136,6 +142,7 @@ final class NotificationPreferences: Codable, Equatable, Hashable {
         webPlacement: String? = nil,
         webWidthFraction: CGFloat? = nil,
         webAutoplay: Bool = false,
+        webMuted: Bool = true,
         webLoops: Bool = false
     ) {
         self.bundledIconId = bundledIconId
@@ -158,6 +165,7 @@ final class NotificationPreferences: Codable, Equatable, Hashable {
         self.webPlacement = webPlacement
         self.webWidthFraction = webWidthFraction
         self.webAutoplay = webAutoplay
+        self.webMuted = webMuted
         self.webLoops = webLoops
     }
 
@@ -186,6 +194,7 @@ final class NotificationPreferences: Codable, Equatable, Hashable {
             webPlacement: webPlacement,
             webWidthFraction: webWidthFraction,
             webAutoplay: webAutoplay,
+            webMuted: webMuted,
             webLoops: webLoops
         )
     }

--- a/clients/macos-swift/VibeCare/VibeCare/Models/PluginRoster.swift
+++ b/clients/macos-swift/VibeCare/VibeCare/Models/PluginRoster.swift
@@ -115,6 +115,32 @@ struct PluginRoster: Equatable, Sendable {
         guard let entry = entry(id: pluginID) else { return nil }
         return url(for: entry, path: path)
     }
+
+    /// An INITIAL-load URL for a plugin-relative path — `url(for:path:)` plus
+    /// the token handoff `handoffURL(for:)` performs.
+    ///
+    /// Both halves are needed and neither existing method has both.
+    /// `handoffURL(for:)` carries the token but only ever points at a plugin's
+    /// root; `url(for:path:)` reaches a sub-path but carries no token — which
+    /// is right for an alert action, since that is followed inside a web view
+    /// that already went through the handoff and holds the cookie. An alert's
+    /// web panel is the *first* load in a web view of its own, so it needs
+    /// both: no token means core's auth wall, no path means every panel
+    /// showing the plugin's index page.
+    ///
+    /// Nil when the plugin is not in the roster — it may have died between the
+    /// schedule being authored and the alert firing, and a break that opens on
+    /// core's error page is worse than a break with no panel.
+    func handoffURL(for pluginID: String, path: String) -> URL? {
+        guard let resolved = url(for: pluginID, path: path),
+              var comps = URLComponents(url: resolved, resolvingAgainstBaseURL: false)
+        else { return nil }
+        // Appended rather than assigned: `url(for:path:)` preserves any query
+        // the caller's path carried, and replacing `queryItems` outright would
+        // silently drop it.
+        comps.queryItems = (comps.queryItems ?? []) + [URLQueryItem(name: "vc", value: token)]
+        return comps.url
+    }
 }
 
 /// A transient, native notification originating from a plugin.

--- a/clients/macos-swift/VibeCare/VibeCare/Services/GlobalNotificationSettings.swift
+++ b/clients/macos-swift/VibeCare/VibeCare/Services/GlobalNotificationSettings.swift
@@ -446,6 +446,9 @@ struct GlobalNotificationSettings: Equatable, Sendable {
     if let value = parameters["web_autoplay"].flatMap(Bool.init) {
       preferences.webAutoplay = value
     }
+    if let value = parameters["web_muted"].flatMap(Bool.init) {
+      preferences.webMuted = value
+    }
     if let value = parameters["web_loop"].flatMap(Bool.init) {
       preferences.webLoops = value
     }

--- a/clients/macos-swift/VibeCare/VibeCare/Services/GlobalNotificationSettings.swift
+++ b/clients/macos-swift/VibeCare/VibeCare/Services/GlobalNotificationSettings.swift
@@ -433,6 +433,20 @@ struct GlobalNotificationSettings: Equatable, Sendable {
       preferences.taskTimerCompletionLabel = label
     }
 
+    // Web panel — the action's alone, with no global counterpart. What to load
+    // during a break is content, not appearance, which is the same reason
+    // `task_timer_seconds` has no global default either. The three modifiers
+    // are inert without `web_url`; `VibeNotifyConfig` reads none of them once
+    // it resolves to no panel.
+    if let spec = parameters["web_url"], !spec.isEmpty {
+      preferences.webURLSpec = spec
+    }
+    preferences.webPlacement = parameters["web_side"]
+    preferences.webWidthFraction = parameters["web_width"].flatMap(Double.init).map { CGFloat($0) }
+    if let value = parameters["web_autoplay"].flatMap(Bool.init) {
+      preferences.webAutoplay = value
+    }
+
     return preferences
   }
 }

--- a/clients/macos-swift/VibeCare/VibeCare/Services/GlobalNotificationSettings.swift
+++ b/clients/macos-swift/VibeCare/VibeCare/Services/GlobalNotificationSettings.swift
@@ -446,6 +446,9 @@ struct GlobalNotificationSettings: Equatable, Sendable {
     if let value = parameters["web_autoplay"].flatMap(Bool.init) {
       preferences.webAutoplay = value
     }
+    if let value = parameters["web_loop"].flatMap(Bool.init) {
+      preferences.webLoops = value
+    }
 
     return preferences
   }

--- a/clients/macos-swift/VibeCare/VibeCare/Services/VibeNotifyConfiguration.swift
+++ b/clients/macos-swift/VibeCare/VibeCare/Services/VibeNotifyConfiguration.swift
@@ -54,6 +54,70 @@ enum VibeNotifyConfig {
 
   private static let logger = Logger(label: "com.vibecare.vibe-notify-config")
 
+  // MARK: - Plugin web panels
+
+  /// How a `plugin:<id>/<path>` web-panel spec becomes a loadable URL, set by
+  /// the plugin shell once its roster is live.
+  ///
+  /// A hook rather than a direct call because the roster lives on
+  /// `PluginShellService`, which is a `@StateObject` owned by `Dashboard` and
+  /// has no singleton — and should not grow one for this. It is also genuinely
+  /// dynamic: the base URL and the session token both change when core
+  /// restarts, so this must be read at delivery time and never cached.
+  ///
+  /// `nil` until the shell starts, which is the honest answer for an alert
+  /// that fires before the plugin list exists: no panel, rather than a panel
+  /// pointed at nothing.
+  @MainActor static var pluginWebURLResolver: ((_ pluginID: String, _ path: String) -> URL?)?
+
+  /// A `web_url` action parameter resolved to something a web view can load.
+  ///
+  /// Two accepted forms, and everything else is rejected rather than guessed
+  /// at. In particular a bare `example.com` is *not* upgraded to
+  /// `https://example.com`: `URL(string:)` accepts it happily as a relative
+  /// URL, the web view then fails to load it, and the user gets a blank panel
+  /// with no explanation. A log line and no panel is the better failure.
+  @MainActor
+  static func resolveWebURL(_ spec: String) -> URL? {
+    let trimmed = spec.trimmingCharacters(in: .whitespacesAndNewlines)
+
+    if trimmed.hasPrefix("plugin:") {
+      let body = String(trimmed.dropFirst("plugin:".count))
+      // `blink-jump` and `blink-jump/index.html` both work; the id is
+      // everything up to the first slash.
+      let separator = body.firstIndex(of: "/")
+      let pluginID = separator.map { String(body[body.startIndex..<$0]) } ?? body
+      let path = separator.map { String(body[body.index(after: $0)...]) } ?? ""
+      guard !pluginID.isEmpty else {
+        logger.error("web_url names no plugin", metadata: ["web_url": "\(spec)"])
+        return nil
+      }
+      guard let resolver = pluginWebURLResolver else {
+        logger.error(
+          "web_url names a plugin but the plugin shell has not started; showing no panel",
+          metadata: ["plugin": "\(pluginID)"])
+        return nil
+      }
+      guard let url = resolver(pluginID, path) else {
+        logger.error(
+          "web_url names a plugin that is not in the roster; showing no panel",
+          metadata: ["plugin": "\(pluginID)"])
+        return nil
+      }
+      return url
+    }
+
+    guard trimmed.hasPrefix("https://") || trimmed.hasPrefix("http://"),
+          let url = URL(string: trimmed)
+    else {
+      logger.error(
+        "web_url is neither an http(s) URL nor plugin:<id>; showing no panel",
+        metadata: ["web_url": "\(spec)"])
+      return nil
+    }
+    return url
+  }
+
   // MARK: - Ambient Window Height
 
   /// The window height an `.ambient` rich alert needs, which is not the height
@@ -222,7 +286,21 @@ enum VibeNotifyConfig {
     // error to explain why. A duration the caller explicitly asked for is a
     // stronger signal than a blur flag that may just be an unconsidered
     // default, so this upgrades rather than silently drops the ring.
-    let mode: AlertMode = (taskTimer != nil || prefs.screenBlurEnabled) ? .interrupt : .ambient
+    //
+    // A web panel forces it for the same reason: `effectiveWebPanel` is nil in
+    // `.ambient`, so the action would get no panel and no explanation.
+    let webPanel: WebPanel? = prefs.webURLSpec
+      .flatMap(resolveWebURL)
+      .map { url in
+        WebPanel(
+          url: url,
+          placement: prefs.webPlacement == "trailing" ? .trailing : .leading,
+          widthFraction: prefs.webWidthFraction ?? WebPanel.defaultWidthFraction,
+          allowsAutoplay: prefs.webAutoplay)
+      }
+
+    let mode: AlertMode =
+      (taskTimer != nil || webPanel != nil || prefs.screenBlurEnabled) ? .interrupt : .ambient
 
     var buttons: [StandardNotification.Button] = []
     var autoDismiss: StandardNotification.AutoDismiss?
@@ -254,6 +332,13 @@ enum VibeNotifyConfig {
           metadata: ["auto_dismiss_after": "\(autoDismissAfter)"]
         )
       }
+    } else if webPanel != nil {
+      // A web panel with no task timer would otherwise be an alert nobody can
+      // keep: no buttons are added above, `RichNotificationView` suppresses
+      // click-anywhere-to-dismiss whenever a panel is present, and the `else`
+      // branch below would close it after `quickDismissDelay` — three seconds
+      // of a video, then gone. Give it a way out and no deadline instead.
+      buttons = [StandardNotification.Button(title: "Close", style: .primary, action: {})]
     } else {
       autoDismiss = StandardNotification.AutoDismiss(
         delay: prefs.autoDismissAfter ?? quickDismissDelay, indicator: .none)
@@ -261,8 +346,13 @@ enum VibeNotifyConfig {
 
     let notification = RichNotification(
       illustration: illustration,
+      webPanel: webPanel,
       title: title,
       message: message,
+      // Only with a panel, and only because the panel is what takes
+      // click-anywhere away. Without it the sentence would name an escape the
+      // renderer does not offer, which is worse than saying nothing.
+      footnote: webPanel != nil ? "Press ESC to skip" : nil,
       buttons: buttons,
       taskTimer: taskTimer,
       autoDismiss: autoDismiss,

--- a/clients/macos-swift/VibeCare/VibeCare/Services/VibeNotifyConfiguration.swift
+++ b/clients/macos-swift/VibeCare/VibeCare/Services/VibeNotifyConfiguration.swift
@@ -296,7 +296,8 @@ enum VibeNotifyConfig {
           url: url,
           placement: prefs.webPlacement == "trailing" ? .trailing : .leading,
           widthFraction: prefs.webWidthFraction ?? WebPanel.defaultWidthFraction,
-          allowsAutoplay: prefs.webAutoplay)
+          allowsAutoplay: prefs.webAutoplay,
+          loops: prefs.webLoops)
       }
 
     let mode: AlertMode =

--- a/clients/macos-swift/VibeCare/VibeCare/Services/VibeNotifyConfiguration.swift
+++ b/clients/macos-swift/VibeCare/VibeCare/Services/VibeNotifyConfiguration.swift
@@ -297,6 +297,7 @@ enum VibeNotifyConfig {
           placement: prefs.webPlacement == "trailing" ? .trailing : .leading,
           widthFraction: prefs.webWidthFraction ?? WebPanel.defaultWidthFraction,
           allowsAutoplay: prefs.webAutoplay,
+          startsMuted: prefs.webMuted,
           loops: prefs.webLoops)
       }
 

--- a/clients/macos-swift/VibeCare/VibeCare/ViewModels/NotificationActionViewModel.swift
+++ b/clients/macos-swift/VibeCare/VibeCare/ViewModels/NotificationActionViewModel.swift
@@ -155,6 +155,12 @@ final class NotificationActionViewModel {
             parameters.removeValue(forKey: "task_timer_seconds")
         }
 
+        // The break's activity, for the same reason: a page opened beside the
+        // countdown is what the break *is*. Written before the appearance
+        // guard below, so an action that takes the global appearance still
+        // keeps its activity.
+        parameters = ScheduleActionCard.applyingWebPanel(preferences, to: parameters)
+
         // Appearance — written only when this action overrides the global
         // settings, and actively cleared when it does not. See
         // `ScheduleActionCard.serializeNotificationPreferences` for why the

--- a/clients/macos-swift/VibeCare/VibeCare/Views/Dashboard/Dashboard.swift
+++ b/clients/macos-swift/VibeCare/VibeCare/Views/Dashboard/Dashboard.swift
@@ -26,6 +26,14 @@ public struct Dashboard: View {
         }
         .task {
           pluginShell.start()
+          // Lets a schedule alert open `plugin:blink-jump` in its web panel.
+          // The closure reads `roster` at delivery time rather than capturing
+          // it: core's base URL and session token both change when it
+          // restarts, so a resolved URL cached here would be a stale
+          // credential the next time an alert fired.
+          VibeNotifyConfig.pluginWebURLResolver = { [weak pluginShell] id, path in
+            pluginShell?.roster.handoffURL(for: id, path: path)
+          }
         }
 
       // Global status bar

--- a/clients/macos-swift/VibeCare/VibeCare/Views/Schedules/ActionCardView.swift
+++ b/clients/macos-swift/VibeCare/VibeCare/Views/Schedules/ActionCardView.swift
@@ -255,7 +255,7 @@ struct ScheduleActionCard: Identifiable, Equatable {
     ) -> [String: String] {
         var result = parameters
         guard let spec = prefs.webURLSpec, !spec.isEmpty else {
-            for key in ["web_url", "web_side", "web_width", "web_autoplay", "web_loop"] {
+            for key in ["web_url", "web_side", "web_width", "web_autoplay", "web_muted", "web_loop"] {
                 result.removeValue(forKey: key)
             }
             return result
@@ -268,6 +268,7 @@ struct ScheduleActionCard: Identifiable, Equatable {
             result["web_side"] = side
         }
         result["web_autoplay"] = String(prefs.webAutoplay)
+        result["web_muted"] = String(prefs.webMuted)
         result["web_loop"] = String(prefs.webLoops)
         return result
     }
@@ -696,9 +697,25 @@ struct NotificationActionParametersView: View {
                 // autoplay and refuse unmuted autoplay without a user gesture,
                 // so a label promising sound would be promising something no
                 // policy allows. The player keeps its own unmute control.
-                Toggle("Start playing automatically (muted)", isOn: $vm.preferences.webAutoplay)
+                Toggle("Start playing automatically", isOn: $vm.preferences.webAutoplay)
                     .toggleStyle(.switch)
                     .font(.caption)
+
+                Toggle("Start muted", isOn: $vm.preferences.webMuted)
+                    .toggleStyle(.switch)
+                    .font(.caption)
+
+                // Not a warning about a mistake, a warning about a *silent*
+                // one: a browser refuses unmuted autoplay without a user
+                // gesture, and the refusal looks exactly like a video waiting
+                // to be clicked.
+                if vm.preferences.webAutoplay && !vm.preferences.webMuted {
+                    Label(
+                        "Unmuted autoplay is usually blocked — the video will sit waiting for a click.",
+                        systemImage: "exclamationmark.triangle")
+                        .font(.caption)
+                        .foregroundColor(.orange)
+                }
 
                 Toggle("Loop until the break ends", isOn: $vm.preferences.webLoops)
                     .toggleStyle(.switch)

--- a/clients/macos-swift/VibeCare/VibeCare/Views/Schedules/ActionCardView.swift
+++ b/clients/macos-swift/VibeCare/VibeCare/Views/Schedules/ActionCardView.swift
@@ -289,12 +289,12 @@ struct ScheduleActionCardView: View {
         VStack(alignment: .leading, spacing: 12) {
             // Header
             HStack(spacing: 12) {
-                Image(systemName: card.type.iconName)
+                Image(systemName: ActionKind.iconName(for: card.type, parameters: card.parameters))
                     .font(.title3)
                     .foregroundColor(colorForType(card.type))
 
                 VStack(alignment: .leading, spacing: 2) {
-                    Text(card.type.displayName)
+                    Text(ActionKind.displayName(for: card.type, parameters: card.parameters))
                         .font(.headline)
                         .fontWeight(.semibold)
 
@@ -448,6 +448,14 @@ struct NotificationActionParametersView: View {
     // Logger
     private let logger = Logger(label: "com.vibecare.notification-action-params")
 
+    /// Whether this action gets the rich editor — see `ActionKind.isRich`,
+    /// which also treats an existing countdown or web panel as evidence so
+    /// actions authored by the MCP server, the CLI or a template do not open
+    /// in an editor with no controls for their own settings.
+    private var isRich: Bool {
+        ActionKind.isRich(viewModel.parameters)
+    }
+
     var body: some View {
         @Bindable var vm = viewModel
 
@@ -458,9 +466,15 @@ struct NotificationActionParametersView: View {
 
             messageCustomizationSection
 
-            breakCountdownSection
+            // Rich only. A plain notification is a line of text in a corner; a
+            // countdown ring and an embedded page are the things that make it
+            // something else, so they belong to the kind of action that was
+            // chosen for them and not in every notification's editor.
+            if isRich {
+                breakCountdownSection
 
-            breakActivitySection
+                breakActivitySection
+            }
 
             // Appearance: how it looks. Collapsed by default, because the
             // answer for almost every action is "the same as everything else",

--- a/clients/macos-swift/VibeCare/VibeCare/Views/Schedules/ActionCardView.swift
+++ b/clients/macos-swift/VibeCare/VibeCare/Views/Schedules/ActionCardView.swift
@@ -2,6 +2,9 @@ import SwiftUI
 import UniformTypeIdentifiers
 import SVGView
 import Logging
+// For `WebPanel`'s width bounds, so the editor's slider cannot offer a value
+// the library will clamp away behind the author's back.
+import VibeNotify
 
 // MARK: - ScheduleActionCard Model
 struct ScheduleActionCard: Identifiable, Equatable {
@@ -456,13 +459,37 @@ struct NotificationActionParametersView: View {
         ActionKind.isRich(viewModel.parameters)
     }
 
+    /// Whether a web panel is what this alert shows.
+    ///
+    /// Also the answer to "is the illustration drawn?" — it is not.
+    /// `RichNotification.effectiveIllustration` returns nil whenever a web
+    /// panel is present, because the panel *is* the picture and two focal
+    /// points is the composition problem the renderer has metrics to avoid. So
+    /// the icon picker is hidden rather than left there setting a value
+    /// nothing will read.
+    private var hasWebPanel: Bool {
+        !(viewModel.preferences.webURLSpec ?? "").isEmpty
+    }
+
+    /// The width the panel will actually take, defaulted the way the library
+    /// defaults it so the slider never shows a position the alert will not use.
+    private var effectiveWebWidth: CGFloat {
+        viewModel.preferences.webWidthFraction ?? WebPanel.defaultWidthFraction
+    }
+
     var body: some View {
         @Bindable var vm = viewModel
 
         VStack(alignment: .leading, spacing: 16) {
             // Content: what this notification says. Always visible — it is the
             // only part of an action that has no global counterpart.
-            svgIconSection
+            //
+            // Except when a web panel is present, where the renderer discards
+            // the illustration outright (`effectiveIllustration`) — leaving the
+            // picker on screen would be offering a choice with no effect.
+            if !hasWebPanel {
+                svgIconSection
+            }
 
             messageCustomizationSection
 
@@ -511,8 +538,17 @@ struct NotificationActionParametersView: View {
 
                 Group {
                     presetSection
-                    positionSection
-                    sizeSection
+                    // Position and size are ignored outright once the alert
+                    // takes the screen: a break countdown or a web panel
+                    // selects `.interrupt`, and that mode's configuration
+                    // passes nil for position, width and height. Showing a
+                    // corner picker there offers a choice the renderer throws
+                    // away. `behaviorSection` stays — the blur controls it
+                    // holds are what the interrupt backdrop is made of.
+                    if !isRich {
+                        positionSection
+                        sizeSection
+                    }
                     behaviorSection
                 }
                 .disabled(!vm.overridesAppearance)
@@ -626,6 +662,35 @@ struct NotificationActionParametersView: View {
                 ))
                 .textFieldStyle(.roundedBorder)
                 .font(.system(.caption, design: .monospaced))
+
+                // Size and side. Both are properties of *this* activity rather
+                // than of the user's taste — a vertical Short wants a narrow
+                // column and a landscape video a wide one — which is why
+                // picking a catalogue entry sets the width and why there is no
+                // global default for either.
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Size: \(Int(effectiveWebWidth * 100))% of the screen")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+
+                    Slider(
+                        value: Binding(
+                            get: { Double(effectiveWebWidth) },
+                            set: { vm.preferences.webWidthFraction = CGFloat($0) }
+                        ),
+                        in: Double(WebPanel.minimumWidthFraction)...Double(WebPanel.maximumWidthFraction)
+                    )
+                }
+
+                Picker("Side", selection: Binding(
+                    get: { vm.preferences.webPlacement == "trailing" ? "trailing" : "leading" },
+                    set: { vm.preferences.webPlacement = $0 }
+                )) {
+                    Text("Left").tag("leading")
+                    Text("Right").tag("trailing")
+                }
+                .pickerStyle(.segmented)
+                .font(.caption)
 
                 // Says "muted" because it always is: browsers grant muted
                 // autoplay and refuse unmuted autoplay without a user gesture,

--- a/clients/macos-swift/VibeCare/VibeCare/Views/Schedules/ActionCardView.swift
+++ b/clients/macos-swift/VibeCare/VibeCare/Views/Schedules/ActionCardView.swift
@@ -235,6 +235,37 @@ struct ScheduleActionCard: Identifiable, Equatable {
             result["task_timer_completion_label"] = completionLabel
         }
 
+        result = Self.applyingWebPanel(prefs, to: result)
+
+        return result
+    }
+
+    /// The four `web_*` keys, written together and removed together.
+    ///
+    /// Removed together is the load-bearing half: clearing the activity has to
+    /// clear the width and the autoplay flag with it, or an action switched
+    /// from a Short back to "countdown only" keeps a 36% column width that
+    /// nothing on screen explains any more, and reinstates it the moment any
+    /// activity is picked again.
+    static func applyingWebPanel(
+        _ prefs: NotificationPreferences, to parameters: [String: String]
+    ) -> [String: String] {
+        var result = parameters
+        guard let spec = prefs.webURLSpec, !spec.isEmpty else {
+            for key in ["web_url", "web_side", "web_width", "web_autoplay", "web_loop"] {
+                result.removeValue(forKey: key)
+            }
+            return result
+        }
+        result["web_url"] = spec
+        if let fraction = prefs.webWidthFraction {
+            result["web_width"] = String(format: "%.2f", Double(fraction))
+        }
+        if let side = prefs.webPlacement, !side.isEmpty {
+            result["web_side"] = side
+        }
+        result["web_autoplay"] = String(prefs.webAutoplay)
+        result["web_loop"] = String(prefs.webLoops)
         return result
     }
 
@@ -429,6 +460,8 @@ struct NotificationActionParametersView: View {
 
             breakCountdownSection
 
+            breakActivitySection
+
             // Appearance: how it looks. Collapsed by default, because the
             // answer for almost every action is "the same as everything else",
             // and that answer now lives in Settings › Notifications.
@@ -530,6 +563,94 @@ struct NotificationActionParametersView: View {
                     .font(.caption)
                     .foregroundColor(.secondary)
             }
+        }
+    }
+
+    /// What the break *is*, when it is more than a countdown: a page opened
+    /// beside the timer, from a short curated list or a URL of the author's own.
+    ///
+    /// A list rather than a search box on purpose. A break is twenty seconds
+    /// long, and a user choosing what to watch during one has already spent it
+    /// — so the choosing happens here, once, and costs a click at break time.
+    private var breakActivitySection: some View {
+        @Bindable var vm = viewModel
+
+        return VStack(alignment: .leading, spacing: 8) {
+            Text("Break Activity")
+                .font(.subheadline)
+                .fontWeight(.medium)
+
+            Picker("Activity", selection: Binding(
+                get: { vm.preferences.webURLSpec ?? "" },
+                set: { apply(activityURL: $0) }
+            )) {
+                Text("None — countdown only").tag("")
+                ForEach(BreakActivity.Focus.allCases) { focus in
+                    Section(focus.title) {
+                        ForEach(BreakActivity.all(in: focus)) { activity in
+                            Text(activity.title).tag(activity.url)
+                        }
+                    }
+                }
+                // Keeps a hand-typed URL selectable rather than snapping the
+                // picker back to "None" the moment it stops matching a
+                // catalogue entry.
+                if let spec = vm.preferences.webURLSpec,
+                   !spec.isEmpty, BreakActivity.activity(withURL: spec) == nil {
+                    Section("Custom") {
+                        Text(spec).tag(spec)
+                    }
+                }
+            }
+            .labelsHidden()
+            .font(.caption)
+
+            if let spec = vm.preferences.webURLSpec, !spec.isEmpty {
+                TextField("https://… or plugin:<id>", text: Binding(
+                    get: { spec },
+                    set: { vm.preferences.webURLSpec = $0.isEmpty ? nil : $0 }
+                ))
+                .textFieldStyle(.roundedBorder)
+                .font(.system(.caption, design: .monospaced))
+
+                // Says "muted" because it always is: browsers grant muted
+                // autoplay and refuse unmuted autoplay without a user gesture,
+                // so a label promising sound would be promising something no
+                // policy allows. The player keeps its own unmute control.
+                Toggle("Start playing automatically (muted)", isOn: $vm.preferences.webAutoplay)
+                    .toggleStyle(.switch)
+                    .font(.caption)
+
+                Toggle("Loop until the break ends", isOn: $vm.preferences.webLoops)
+                    .toggleStyle(.switch)
+                    .font(.caption)
+
+                Text("Opens beside the countdown, filling most of the screen. YouTube links — Shorts and ones with a start time included — become an embedded player automatically. Clicking the page will not dismiss the alert; Done, Skip and ESC still will.")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+        }
+    }
+
+    /// Applies a picked activity: the URL always, and the column width and
+    /// break duration only as *defaults*.
+    ///
+    /// Width comes along because a vertical Short in the landscape column is
+    /// letterboxed into two black wings, which is a property of the video and
+    /// not something an author should have to know. The duration is seeded only
+    /// when none is set — an author who already chose 20 seconds meant it, and
+    /// replacing that with a suggestion would overwrite a decision with a guess.
+    private func apply(activityURL: String) {
+        let vm = viewModel
+        guard !activityURL.isEmpty else {
+            vm.preferences.webURLSpec = nil
+            return
+        }
+        vm.preferences.webURLSpec = activityURL
+        guard let activity = BreakActivity.activity(withURL: activityURL) else { return }
+        vm.preferences.webWidthFraction = CGFloat(activity.widthFraction)
+        if vm.preferences.taskTimerSeconds == nil {
+            vm.preferences.taskTimerSeconds = TimeInterval(activity.seconds)
         }
     }
 

--- a/clients/macos-swift/VibeCare/VibeCare/Views/Schedules/ActionCardView.swift
+++ b/clients/macos-swift/VibeCare/VibeCare/Views/Schedules/ActionCardView.swift
@@ -705,6 +705,17 @@ struct NotificationActionParametersView: View {
                     .toggleStyle(.switch)
                     .font(.caption)
 
+                // Stated rather than detected. Reading
+                // `ProcessInfo.isLowPowerModeEnabled` here would describe the
+                // machine *authoring* the action, which is not necessarily the
+                // one showing the alert, and a false "unavailable" would be
+                // worse than the plain fact.
+                if vm.preferences.webAutoplay {
+                    Text("Autoplay never starts while macOS Low Power Mode is on — WebKit requires a real click there, whatever the setting says.")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+
                 // Not a warning about a mistake, a warning about a *silent*
                 // one: a browser refuses unmuted autoplay without a user
                 // gesture, and the refusal looks exactly like a video waiting

--- a/clients/macos-swift/VibeCare/VibeCare/Views/Schedules/ActionEditSheet.swift
+++ b/clients/macos-swift/VibeCare/VibeCare/Views/Schedules/ActionEditSheet.swift
@@ -12,6 +12,9 @@ struct ActionEditSheet: View {
     @StateObject private var actionService = ActionService()
     @State private var viewModel: NotificationActionViewModel
     @State private var actionType: ActionType
+    /// The menu's selection. `ActionType` cannot serve as one — rich and plain
+    /// notifications share it — so the picker binds to an `ActionKind.id`.
+    @State private var actionKindID: String
     @State private var isSaving = false
     @State private var errorMessage: String?
     @State private var showingPreview = false
@@ -33,6 +36,13 @@ struct ActionEditSheet: View {
 
         // Initialize state properties
         self._actionType = State(initialValue: actionCard.type)
+        // Derived from the card's own parameters, so an action carrying a
+        // countdown or a web panel opens on "Send Rich Notification" whether or
+        // not it was authored here — see `ActionKind.isRich`.
+        self._actionKindID = State(
+            initialValue: actionCard.type == .notification
+                && ActionKind.isRich(actionCard.parameters)
+                ? "notification.rich" : actionCard.type.rawValue)
         self._viewModel = State(initialValue: NotificationActionViewModel(
             preferences: actionCard.notificationPreferences,
             parameters: actionCard.type.seedingDefaults(into: actionCard.parameters),
@@ -63,18 +73,28 @@ struct ActionEditSheet: View {
                         Text("Action Type")
                             .font(.headline)
 
-                        Picker("Action Type", selection: $actionType) {
-                            ForEach(ActionType.allCases, id: \.self) { type in
-                                Label(type.displayName, systemImage: type.iconName)
-                                    .tag(type)
+                        // Selects an `ActionKind`, not an `ActionType`: rich and
+                        // plain notifications share a type, so a type picker
+                        // shows one entry for two different things and cannot
+                        // switch between them.
+                        Picker("Action Type", selection: $actionKindID) {
+                            ForEach(ActionKind.all) { kind in
+                                Label(kind.title, systemImage: kind.icon)
+                                    .tag(kind.id)
                             }
                         }
                         .pickerStyle(.menu)
-                        .onChange(of: actionType) { _, newType in
-                            // Reset ViewModel and seed defaults for the new type
+                        .onChange(of: actionKindID) { _, newID in
+                            guard let kind = ActionKind.all.first(where: { $0.id == newID })
+                            else { return }
+                            actionType = kind.type
+                            // Reset ViewModel and seed defaults for the new kind.
+                            // `seedParameters()` carries the rich marker and the
+                            // default activity; `seedingDefaults` fills in the
+                            // per-type fields for everything else.
                             viewModel = NotificationActionViewModel(
                                 preferences: GlobalNotificationSettings.current.basePreferences(),
-                                parameters: newType.seedingDefaults(into: [:]),
+                                parameters: kind.type.seedingDefaults(into: kind.seedParameters()),
                                 overridesAppearance: false
                             )
                         }

--- a/clients/macos-swift/VibeCare/VibeCare/Views/Schedules/ScheduleEditView.swift
+++ b/clients/macos-swift/VibeCare/VibeCare/Views/Schedules/ScheduleEditView.swift
@@ -1113,11 +1113,11 @@ struct ScheduleEditView: View {
 
         // Add Action Dropdown
         Menu {
-          ForEach(ActionType.allCases, id: \.self) { type in
+          ForEach(ActionKind.all) { kind in
             Button {
-              addActionCard(type: type)
+              addActionCard(kind: kind)
             } label: {
-              Label(type.displayName, systemImage: type.iconName)
+              Label(kind.title, systemImage: kind.icon)
             }
           }
         } label: {
@@ -1359,8 +1359,11 @@ struct ScheduleEditView: View {
   }
 
   // MARK: - Action Card Management
-  private func addActionCard(type: ActionType) {
-    let newCard = ScheduleActionCard(type: type)
+  private func addActionCard(kind: ActionKind) {
+    // The seed carries the rich marker when there is one, so the card opens in
+    // the editor the user picked from the menu rather than in whichever one its
+    // (empty) parameters happen to imply.
+    let newCard = ScheduleActionCard(type: kind.type, parameters: kind.seedParameters())
     actionCards.append(newCard)
 
     // Eager save to backend with enabled: false (orphaned state)

--- a/clients/macos-swift/VibeCare/VibeCare/Views/Schedules/SchedulesDetail.swift
+++ b/clients/macos-swift/VibeCare/VibeCare/Views/Schedules/SchedulesDetail.swift
@@ -406,11 +406,11 @@ struct ScheduleDetailView: View {
 
                 // Add Action Dropdown Menu
                 Menu {
-                    ForEach(ActionType.allCases, id: \.self) { type in
+                    ForEach(ActionKind.all) { kind in
                         Button {
-                            openCreateActionSheet(type: type)
+                            openCreateActionSheet(kind: kind)
                         } label: {
-                            Label(type.displayName, systemImage: type.iconName)
+                            Label(kind.title, systemImage: kind.icon)
                         }
                     }
                 } label: {
@@ -663,13 +663,15 @@ struct ScheduleDetailView: View {
         }
     }
 
-    private func openCreateActionSheet(type: ActionType) {
+    private func openCreateActionSheet(kind: ActionKind) {
         guard let schedule = schedule, let profileId = AppState.shared.currentProfile?.id else {
             return
         }
 
         actionEditContext = ActionEditContext(
-            actionCard: ScheduleActionCard(type: type),
+            // The seed carries the rich marker, so the sheet opens in the
+            // editor that was picked rather than the one empty parameters imply.
+            actionCard: ScheduleActionCard(type: kind.type, parameters: kind.seedParameters()),
             isCreating: true,
             profileId: profileId,
             schedule: schedule

--- a/clients/macos-swift/VibeCare/vibecare.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/clients/macos-swift/VibeCare/vibecare.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -267,8 +267,8 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/vibecare-io/vibe-notify-macos.git",
       "state": {
-        "revision": "b0c7c2167481779eaf201018456ea0da1d73b3e6",
-        "version": "0.0.6"
+        "revision": "b8284a630f4eba40ffe5f7949b9916a64b1e733d",
+        "version": "0.0.7"
       }
     }
   ],

--- a/docs/superpowers/specs/2026-08-18-web-alert-surface-design.md
+++ b/docs/superpowers/specs/2026-08-18-web-alert-surface-design.md
@@ -1,7 +1,32 @@
 # Web Alert Surface — Design
 
-**Status:** approved, minimal spec
+**Status:** shipped, with amendments — see below before trusting any detail here
 **Scope:** `simple-alerts` (VibeNotify) + `clients/macos-swift` (VibeCare client)
+
+> [!IMPORTANT]
+> **What shipped differs from this document in four ways.** This is the design
+> as approved; it was not rewritten as implementation taught us things. Where
+> the two disagree, the code and `DOCS.md` in `simple-alerts` are right.
+>
+> 1. **The web view lives in the library, not the client.** This document says
+>    the client supplies the `WKWebView` because a library-side one "would
+>    re-fetch unauthenticated". That reasoning was wrong: the library is linked
+>    into the client's own process, so `WKWebsiteDataStore.default()` is the
+>    same cookie jar either way. `WebPanelView` is therefore in VibeNotify, and
+>    authenticated plugin URLs work.
+> 2. **`Presentation` exists.** A YouTube link is loaded in an `<iframe>` in a
+>    document whose origin is a reserved `.invalid` host (`.player`), not
+>    top-level (`.direct`). Getting this wrong produces Error 153 (no origin)
+>    or Error 152 (the target's own origin). See `DOCS.md § Web panel`.
+> 3. **More knobs than described**: `startsMuted` (default **on**), `loops`,
+>    and YouTube URL rewriting for `/shorts/`, `/live/` and `?t=` offsets. The
+>    action keys gained `web_muted` and `web_loop` to match.
+> 4. **A separate authoring kind.** The client grew `ActionKind` and a "Send
+>    Rich Notification" menu entry rather than putting these controls in the
+>    plain notification editor. Still `type: notification` on the wire.
+>
+> Also worth knowing and absent here entirely: **autoplay cannot work while
+> macOS Low Power Mode is on**, whatever any setting says.
 
 ## Goal
 

--- a/docs/superpowers/specs/2026-08-18-web-alert-surface-design.md
+++ b/docs/superpowers/specs/2026-08-18-web-alert-surface-design.md
@@ -1,0 +1,119 @@
+# Web Alert Surface — Design
+
+**Status:** approved, minimal spec
+**Scope:** `simple-alerts` (VibeNotify) + `clients/macos-swift` (VibeCare client)
+
+## Goal
+
+Let an alert embed a live web page beside its text and countdown, so a break
+can *be* something — play blink-jump, watch a video, glance at an inbox —
+instead of only describing something.
+
+## Layout
+
+One inset panel over the dimmed, blurred desktop. Two columns:
+
+```
+┌─ blurred + dimmed desktop ──────────────────────────────────┐
+│   ┌──────────────────────────┬────────────────────┐         │
+│   │                          │            ◜ 0:20 ◝ │         │
+│   │        web panel         │  Title              │         │
+│   │   (game / video / page)  │  Message            │         │
+│   │                          │                     │         │
+│   │                          │  [ Done ] [ Skip ]  │         │
+│   │                          │  footnote           │         │
+│   └──────────────────────────┴────────────────────┘         │
+└──────────────────────────────────────────────────────────────┘
+```
+
+The right column is the existing rich-renderer chrome, unchanged: title,
+message, countdown ring, buttons, footnote, and the same `Legibility` text
+treatment. The only new element is the web panel.
+
+**Countdown moves to the top of the rail** in this layout. Everywhere else it
+stays where it is. The rail reads top-down as *how long is left → what to do →
+how to leave*, which is the order the mockup asks for and the order that
+survives the web panel being the thing the eye lands on first.
+
+## Library: `RichNotification.webPanel`
+
+A new optional property on the model the renderer already takes, **not** a new
+model and not a new renderer. A parallel `WebNotification` would have to
+re-declare title, message, footnote, buttons, task timer, auto-dismiss, mode
+and acknowledgement label, and would fork `styled()`, the scrim strategy, the
+entrance animation and the button-outcome routing — roughly 200 lines of
+subtle duplication for one extra element.
+
+```swift
+public struct WebPanel: Sendable, Equatable {
+  public enum Placement: Sendable { case leading, trailing }
+
+  public let url: URL
+  public let placement: Placement      // default .leading
+  public let widthFraction: CGFloat    // of the panel, clamped 0.3...0.85, default 0.64
+  public let allowsAutoplay: Bool      // default false
+}
+```
+
+- `webPanel` and `illustration` are mutually exclusive. When both are set the
+  web panel wins and the illustration is not drawn — the panel *is* the
+  picture, and two competing focal points is the composition problem the
+  renderer already has metrics to avoid.
+- Ignored in `.ambient`. A 380×210 toast has no room for a web view, and
+  `effectiveTaskTimer` already establishes the precedent that the model
+  reinterprets rather than trusting a caller's mode-incoherent combination.
+
+### Interaction changes when a web panel is present
+
+1. **The full-bleed click-to-dismiss target is suppressed.** Today
+   `RichNotificationView.body(in:)` installs an unconditional screen-sized tap
+   target that cancels the alert. With an interactive panel on screen, a
+   misclick in the margin would end a break the user was in the middle of
+   taking. ESC and the buttons remain.
+2. **The panel takes key focus**, which `.interrupt` already arranges — a game
+   needs the keyboard.
+
+## Web view
+
+`WebPanelView`, an `NSViewRepresentable` over `WKWebView`, using the **default**
+`WKWebsiteDataStore`. That is what makes authentication a non-problem:
+VibeNotify is a SwiftPM dependency running inside the client's own process, so
+the default data store is the same jar the client's `PluginWebView` already
+writes core's `vc_session` cookie into. A plugin URL loads authenticated with
+no extra work, and a logged-in webmail stays logged in between breaks.
+
+No basic-auth prompt and no manual token entry are needed for blink-jump.
+
+`allowsAutoplay` sets `mediaTypesRequiringUserActionForPlayback = []`, off by
+default — a video that starts talking on its own is a worse interruption than
+the one it was meant to soften.
+
+## Client wiring
+
+Three new action parameters, alongside the existing `task_timer_seconds`
+family, parsed in `NotificationPreferences` and applied in
+`VibeNotifyConfiguration`:
+
+| key | value |
+|---|---|
+| `web_url` | `https://…`, or `plugin:<id>` / `plugin:<id>/<path>` |
+| `web_side` | `leading` (default) or `trailing` |
+| `web_width` | width fraction, `0.3`–`0.85` |
+| `web_autoplay` | `true` / `false` |
+
+`plugin:` values resolve through `PluginRoster.handoffURL(for:)`, so the token
+handoff and cookie exchange are the ones already in use. A `plugin:` value
+naming a plugin that is not running falls back to a normal alert with no panel
+rather than showing an error page inside a break.
+
+A `web_url` forces `.interrupt`, for the same reason `task_timer_seconds` does.
+
+No proto, database, or CLI-contract change: `Action.parameters` is
+`map<string,string>`.
+
+## Non-goals
+
+- Navigation chrome (back/forward/reload). This is a break surface, not a
+  browser.
+- Injecting scripts into the page or reading anything out of it.
+- `.ambient` support.


### PR DESCRIPTION
> [!NOTE]
> **Unblocked.** [vibe-notify-macos#5](https://github.com/vibecare-io/vibe-notify-macos/pull/5) is merged and tagged `0.0.7`. This branch now builds from a clean clone of the published tag — the `swift package edit` override is gone, and **both** `Package.resolved` files were moved together (SwiftPM and the Xcode workspace copy, which `swift package resolve` does not touch). Verified against a deleted checkout rather than a warm cache.

A break can now be something you *do*. An action opens a page beside its countdown — Blink & Jump, an eye-exercise short, a breathing routine — instead of only telling you to look away.

## Five new action parameters

`Action.parameters` is a free-form `map<string,string>`, so **no proto, database, CLI-contract or MCP change**:

| key | value |
|---|---|
| `web_url` | `https://…`, or `plugin:<id>` / `plugin:<id>/<path>` |
| `web_side` | `leading` (default) or `trailing` |
| `web_width` | the page's share of the screen, `0.3`–`0.85` |
| `web_autoplay` | may media start on its own (default `false`) |
| `web_muted` | start with sound off (default **`true`**) |
| `web_loop` | restart the video when it ends (default `false`) |

## "Send Rich Notification" is its own action kind

The countdown, break activity and web panel were living inside the plain notification's editor, where they are noise for the nine actions in ten that just want a line of text in a corner. They now have their own menu entry, editor, label and icon.

**No ninth `ActionType`.** Rich and plain are both `notification` on the wire — that is what the backend schedules and every other client understands — and the distinction is one only the authoring UI makes. A real enum value would have meant a proto change, regenerated stubs in two languages, backend mapping and executor changes, and an update to every switch over `ActionType`.

**`ActionKind.isRich` does not trust the marker alone**, and that is the load-bearing part: an action carrying `task_timer_seconds` or `web_url` is rich whatever it was authored in. Deciding on the marker alone would open every action written by the MCP server, the CLI or a routine template in the plain editor — which has no controls for either — so the author would find its most important settings missing and the next save would drop them. No migration, no backfill.

## Relevant controls, in both directions

Added: a **size** slider bounded by `WebPanel`'s own clamps (so it cannot offer a value the library will silently discard), a **side** picker, and separate **autoplay** / **muted** toggles.

Removed where they do nothing: the **icon picker** whenever a panel is set (`effectiveIllustration` returns nil there — the panel *is* the picture), and **position/size** for any rich action (a countdown or panel selects `.interrupt`, whose configuration passes nil for all three).

## Plugin URLs

`plugin:<id>` resolves at delivery time through a new `PluginRoster.handoffURL(for:path:)`. Neither existing method would do: `handoffURL(for:)` carries the session token but only reaches a plugin's root, and `url(for:path:)` reaches a sub-path but carries no token. A panel is the first load in a web view of its own and needs both.

Specs are stored **unresolved**: core's base URL and session token both change when it restarts, so a resolved URL saved into an action would be a stale credential sitting in the database.

## Two failure modes chosen deliberately

Both look like omissions:

- A `plugin:` spec naming a plugin not in the roster shows **no panel**. It may have died between authoring and firing, and a break that opens on core's error page is worse than one without a panel.
- A bare `example.com` is **rejected**, not upgraded to `https://`. `URL(string:)` accepts it as a relative URL, the web view then fails to load it, and the user gets a blank panel with no explanation.

## Curated catalogue

A short hand-picked list — eyes, neck, breathing, move-and-follow, plus the built-in blink-jump — because a break is twenty seconds long and a user choosing what to watch during one has already spent it. New rich notifications default to Blink Jump: the only entry that needs no network, cannot be taken down by its publisher, and is subject to nobody's embedding rules.

Two notes on it: the titles are **descriptions, not the publishers' own titles** (nothing was fetched, so printing a real title would mean inventing one — rename freely), and the x.com link from the same list is left out because X requires a login and refuses to be embedded.

## Known limitation

**Autoplay never fires while macOS Low Power Mode is on.** WebKit requires a real click there regardless of any setting. Documented in the editor and in `CLAUDE.md`; deliberately not detected, since the machine authoring an action is not necessarily the one showing the alert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
