### PR TITLE
Say why the backend login item failed to register

### DIFF
--- a/clients/macos-swift/VibeCare/vibecareTests/BackendManagerTests.swift
+++ b/clients/macos-swift/VibeCare/vibecareTests/BackendManagerTests.swift
@@ -1,4 +1,5 @@
 import Testing
+import Foundation
 @testable import vibecare
 
 @Test func staleWhenBackendOlderOrDifferent() {
@@ -30,4 +31,52 @@ import Testing
 
 @Test func doesNotAutoRestartWhenNotStale() {
     #expect(BackendManager.shouldAutoRestart(stale: false, autoReloadEnabled: true) == false)
+}
+
+// --- Failure reporting ----------------------------------------------------
+//
+// The message shown when no backend answered used to always name
+// ~/.vibecare/logs/server.log. That is right only when the server ran and
+// failed. When REGISTRATION failed the server never started, so the file does
+// not exist and naming it sends the reader hunting for evidence nobody wrote.
+
+@Test func failureMessageNamesTheLogWhenRegistrationWasFine() {
+    #expect(BackendManager.failureMessage(registrationFailure: nil)
+            .contains("~/.vibecare/logs/server.log"))
+}
+
+@Test func failureMessageReportsTheRegistrationReasonInstead() {
+    let msg = BackendManager.failureMessage(
+        registrationFailure: "Could not register the VibeCare backend login item (status: requiresApproval).")
+    #expect(msg.contains("requiresApproval"))
+    // Must NOT send the user to a file that this failure never creates.
+    #expect(!msg.contains("server.log"))
+}
+
+// --- Status rendering -----------------------------------------------------
+//
+// A status name alone is not actionable. requiresApproval in particular is
+// invisible from outside the app: nothing hints that a switch in System
+// Settings is what stands between the user and a working backend.
+
+@Test func adviceForRequiresApprovalPointsAtLoginItems() {
+    let advice = BackendRegistrationError.advice(for: "requiresApproval")
+    #expect(advice.contains("Login Items"))
+}
+
+@Test func adviceForNotFoundBlamesTheBuild() {
+    #expect(BackendRegistrationError.advice(for: "notFound").contains("io.vibecare.server.plist"))
+}
+
+@Test func registrationErrorDescriptionCarriesStatusAndAdvice() {
+    let err = BackendRegistrationError(status: "requiresApproval", underlying: nil)
+    let desc = err.errorDescription ?? ""
+    #expect(desc.contains("requiresApproval"))
+    #expect(desc.contains("Login Items"))
+}
+
+@Test func registrationErrorIncludesWhatMacOSSaid() {
+    struct Boom: LocalizedError { var errorDescription: String? { "Operation not permitted" } }
+    let err = BackendRegistrationError(status: "notRegistered", underlying: Boom())
+    #expect((err.errorDescription ?? "").contains("Operation not permitted"))
 }


### PR DESCRIPTION
Diagnostic change only — no mechanism replaced. It makes the one broken step in a clean install explain itself.

## The problem

On a clean install the app says:

> The VibeCare backend didn't start. Check `~/.vibecare/logs/server.log`.

That file **doesn't exist** in this failure, because the server never started. The only message the user gets points at evidence nobody wrote.

macOS reports exactly what went wrong. The app discarded it:

```swift
do { try supervisor.ensureRegistered() }
catch { /* fall through — maybe already running via `just run` */ }
```

## Why this and not a new install mechanism

On budi (clean machine, macOS 26.5.2), four of the five steps between `brew install` and a working client are verifiably fine:

| Step | |
|---|---|
| `brew install` puts VibeCare.app in /Applications | ✅ |
| App asks macOS to register the background service | ❌ **only broken step** |
| Service starts `vibecare-server` | ✅ when registered |
| Server finds the plugins | ✅ `count: 5` from the bundle |
| Client talks gRPC | ✅ |

Budi's own log shows the packaging fix working — `count: 0` on the old release vs `count: 5` from `bundled_dir` on the new one. There are no missing files and nothing in the wrong folder. Replacing the install mechanism would have been guessing at a cause we can't see; this makes the cause visible first.

## What changed

Registration failing is still **not fatal on its own** — a backend started by `just run` or by an earlier launch's agent makes it irrelevant, and that path is unchanged. The reason is now logged either way, and becomes the failure message when no backend answers.

Two previously-indistinguishable cases are now separated:

- **`register()` returning without throwing is not proof the agent will run.** It succeeds while leaving the service `.requiresApproval` — the user got a "background item added" notification and the switch stays off until they act. Re-reading the status afterwards is the only way to tell that from a registration that took.
- **A status name isn't actionable**, so each carries the thing to *do*: `requiresApproval` → System Settings → Login Items & Extensions; `notFound` → the bundle is missing its plist, this build is incomplete.

## Verification

```
$ xcodebuild test -only-testing:vibecareTests ...
** TEST SUCCEEDED **
73 tests passed, 0 failed        (6 new)
```

These tests live in the Xcode target, not SwiftPM — `swift test` doesn't build `BackendManagerTests.swift`, as its pre-existing tests already demonstrated. `swift build` also passes.

## Next

Ship this, run it on budi, read the actual reason, fix that. If it turns out to be `requiresApproval`, the fix is a UI prompt pointing at Login Items — not a new install mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)