### PR TITLE
Have the cask install and start the backend agent

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -426,18 +426,91 @@ jobs:
 
             depends_on macos: :sequoia
 
+            # `binary` must sit directly under `app` with no blank line
+            # between them — `brew style` treats them as one stanza group.
+            # The server ships inside the bundle, so put it on PATH too:
+            # `vibecare-server --help` should not require anyone to type a
+            # path into /Applications.
             app "VibeCare.app"
+            binary "#{appdir}/VibeCare.app/Contents/Resources/vibecare-server"
 
-            # App is Developer ID signed but not notarized; clear quarantine so
-            # Gatekeeper allows first launch.
             postflight do
+              # App is Developer ID signed but not notarized; clear quarantine
+              # so Gatekeeper allows first launch.
               system_command "/usr/bin/xattr",
                              args: ["-dr", "com.apple.quarantine", "#{appdir}/VibeCare.app"],
                              sudo: false
-              # Best-effort: restart the backend only if its LaunchAgent is
-              # already loaded (from a prior app launch). On a fresh install the
-              # agent isn't registered yet (the app registers it via SMAppService
-              # on first launch), so this must NOT abort the install.
+
+              # Install and start the backend's LaunchAgent HERE, rather than
+              # leaving it to the app.
+              #
+              # Everything the app needs is already installed correctly — the
+              # server binary and all five plugins sit in
+              # Contents/Resources/, and when the server runs it finds them
+              # ("discovered plugins ... count: 5"). The only missing piece on
+              # a clean machine was a running process: nothing started it.
+              #
+              # The app was supposed to, via SMAppService. On a clean install
+              # it does not, and it fails silently — measured on a fresh Mac,
+              # launchd knew the label ("io.vibecare.server" => enabled in
+              # print-disabled) while no job existed in the domain, no
+              # ServiceManagement traffic came from the app at launch, and no
+              # error was ever raised for the app to report. The user saw only
+              # "Connection refused" on :50051 with no way to find out why.
+              #
+              # A plist in ~/Library/LaunchAgents has none of that ambiguity:
+              # it exists as a file you can read, launchctl bootstrap either
+              # works or says why, and it runs at every login whether or not
+              # anyone opens the app. The app's own SMAppService call is left
+              # alone and becomes harmless — the label is already loaded, so a
+              # duplicate registration is refused and the backend it wanted is
+              # the one already running.
+              agent_plist = File.expand_path("~/Library/LaunchAgents/io.vibecare.server.plist")
+              server      = "#{appdir}/VibeCare.app/Contents/Resources/vibecare-server"
+              logs        = File.expand_path("~/.vibecare/logs")
+              FileUtils.mkdir_p(File.dirname(agent_plist))
+              FileUtils.mkdir_p(logs)
+              # StandardOutPath/StandardErrorPath are the point of writing our
+              # own plist rather than reusing the bundle's: the server only
+              # starts logging to ~/.vibecare/logs/server.log once it is far
+              # enough along to configure logging. Anything that kills it
+              # before that — a port already bound, a migration failure —
+              # previously left no trace anywhere.
+              File.write(agent_plist, <<~PLIST)
+                <?xml version="1.0" encoding="UTF-8"?>
+                <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+                <plist version="1.0">
+                <dict>
+                    <key>Label</key><string>io.vibecare.server</string>
+                    <key>ProgramArguments</key>
+                    <array>
+                        <string>#{server}</string>
+                        <string>--port</string><string>50051</string>
+                        <string>--web-port</string><string>8080</string>
+                    </array>
+                    <key>RunAtLoad</key><true/>
+                    <key>KeepAlive</key><dict><key>SuccessfulExit</key><false/></dict>
+                    <key>ProcessType</key><string>Background</string>
+                    <key>StandardOutPath</key><string>#{logs}/agent.out.log</string>
+                    <key>StandardErrorPath</key><string>#{logs}/agent.err.log</string>
+                </dict>
+                </plist>
+              PLIST
+
+              # Bootout first so an upgrade replaces a running agent instead of
+              # colliding with it. Must not abort the install: on a first
+              # install there is nothing to bootout.
+              system_command "/bin/launchctl",
+                             args:         ["bootout", "gui/#{Process.uid}/io.vibecare.server"],
+                             sudo:         false,
+                             must_succeed: false
+              system_command "/bin/launchctl",
+                             args:         ["bootstrap", "gui/#{Process.uid}", agent_plist],
+                             sudo:         false,
+                             must_succeed: false
+              # RunAtLoad covers a fresh bootstrap; kickstart covers the case
+              # where the label was already loaded and needs to pick up the
+              # newly installed binary.
               system_command "/bin/launchctl",
                              args:         ["kickstart", "-k", "gui/#{Process.uid}/io.vibecare.server"],
                              sudo:         false,
@@ -458,8 +531,22 @@ jobs:
             # so it cannot respawn the backend, then quit the app that would
             # re-register it. Placement is not free either — `brew style`
             # requires uninstall to sit between postflight and zap.
+            #
+            # `trash:`, NOT `delete:`, for the plist the postflight writes.
+            # Homebrew runs `delete:` under sudo — it is meant for root-owned
+            # paths — so on a user file it prompts for a password, and in a
+            # non-interactive uninstall it fails the whole operation:
+            #   sudo: a terminal is required to read the password
+            #   Error: Failure while executing; `/usr/bin/sudo ... /bin/rm` exited with 1
+            # which aborts partway, leaving the app installed and the PATH
+            # symlink behind. `trash:` needs no privileges.
+            #
+            # Removing the file matters as much as booting the agent out:
+            # a plist left in ~/Library/LaunchAgents reloads at the next login
+            # and points into /Applications at an app that is no longer there.
             uninstall launchctl: "io.vibecare.server",
-                      quit:      "io.vibecare.app"
+                      quit:      "io.vibecare.app",
+                      trash:     "~/Library/LaunchAgents/io.vibecare.server.plist"
 
             # Alphabetised, and zap kept directly after uninstall, because
             # `brew style` flags both otherwise.


### PR DESCRIPTION
`brew install` puts every file in the right place and starts nothing. On a clean Mac that produces an app that opens and immediately fails:

```
gRPC operation failed: unavailable: Could not establish a connection to
[ipv4]127.0.0.1:50051 ... Connection refused (errno: 61)
Successfully loaded 0 profiles
```

## Nothing was missing

The server binary and all five plugins are in `Contents/Resources/`, and when the server runs it finds them — the same clean machine logged:

```
discovered plugins {"bundled_dir": "/Applications/VibeCare.app/Contents/Resources/plugins", "count": 5}
```

The only absent thing was **a running process**.

## Why the app wasn't starting it

That was `SMAppService`'s job and on a clean install it silently doesn't happen. On a fresh Mac:

```
launchctl print-disabled gui/505           →  "io.vibecare.server" => enabled   ← label known
launchctl print gui/505/io.vibecare.server →  Could not find service            ← no job loaded
log show | grep -i servicemanagement       →  nothing from the app at launch
```

No error was raised, so there wasn't even anything for the app to report. `.enabled` describes a *record*, not a loaded job — and `ensureRegistered()` returns early on it.

## What this does

The cask writes `~/Library/LaunchAgents/io.vibecare.server.plist` and bootstraps it. A plist has none of that ambiguity: it's a file you can read, `bootstrap` either works or says why, and it runs at every login whether or not anyone opens the app.

The app's own `SMAppService` call is left alone and becomes harmless — the label is already loaded, so a duplicate registration is refused and the backend it wanted is the one already running. **No client change, no client release.**

- **`StandardErrorPath`** is the reason for writing our own plist. The server only logs to `~/.vibecare/logs/server.log` once it's far enough along to configure logging; anything that kills it before that left no trace. It earned its keep on the first failed start: `FATAL Another server already has this database {holder_pid: 57773, remedy: ...}` — previously invisible.
- **`binary`** puts `vibecare-server` on PATH.
- **`trash:` not `delete:`** — Homebrew runs `delete:` under sudo (it's for root-owned paths), so on a user file it prompts for a password and non-interactively aborts the uninstall partway, leaving the app installed and the symlink behind. Found by running it.

## Verified end to end on a true clean slate

No app, no plist, no symlink, no process, port free:

```
$ brew install --cask vibecare
==> Linking Binary 'vibecare-server' to '/opt/homebrew/bin/vibecare-server'
🍺  vibecare was successfully installed!

plist:   installed          backend: PID 37916
agent:   state=running      version: {"version":"v0.8.18.26-1"}
5 plugins up, 5 processes   PATH:    /opt/homebrew/bin/vibecare-server
```

**The app was never launched.**

```
$ brew uninstall --cask vibecare
==> Removing launchctl service io.vibecare.server
==> Trashing files: ~/Library/LaunchAgents/io.vibecare.server.plist
==> Unlinking Binary '/opt/homebrew/bin/vibecare-server'

app removed ✓   plist removed ✓   agent booted out ✓
symlink removed ✓   backend stopped ✓   0 plugin processes ✓
```

`brew style --cask` reports no offenses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)